### PR TITLE
Enable debug from script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ COPY . .
 # Conditionally enable SPLITS which is disabled by default
 ARG splits=false 
 RUN if [ "$splits" = "true" ] ; then ./splits.sh enable; else ./splits.sh disable; fi
+# Conditionally enable DEBUG mode
+ARG debug=false 
+RUN if [ "$debug" = "true" ] ; then ./debug.sh enable; else ./debug.sh disable; fi
 RUN make -j7 \
   && make install \
   && make clean

--- a/debug.sh
+++ b/debug.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+##########################################################################
+#
+# This file is part of FORCE - Framework for Operational Radiometric
+# Correction for Environmental monitoring.
+#
+# Copyright (C) 2013-2020 David Frantz
+#
+# FORCE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FORCE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FORCE.  If not, see <http://www.gnu.org/licenses/>.
+#
+##########################################################################
+
+# this script enables or disables debug mode in FORCE
+
+EXPECTED_ARGS=1
+
+# if wrong number of input args, stop
+if [ $# -ne $EXPECTED_ARGS ]; then
+  echo "Usage: $(basename $0) enable/disable"
+  echo ""
+  exit 1
+fi
+
+if [ $1 == enable ]; then
+  enable=1
+elif [ $1 == disable ]; then
+  enable=0
+else
+  echo "Usage: $(basename $0) enable/disable"
+  echo ""
+  exit 1
+fi
+
+CONST=src/cross-level/const-cl.h
+
+if [ ! -r $CONST ]; then
+  echo "$CONST is not existing/readable"
+  exit 1
+fi
+
+if [ $enable -eq 1 ]; then
+  sed -i -e 's%^[/]*\(#define FORCE_DEBUG\)%\1%' src/cross-level/const-cl.h
+elif [ $enable -eq 0 ]; then
+  sed -i -e 's%^[/]*\(#define FORCE_DEBUG\)%//\1%' src/cross-level/const-cl.h
+fi
+
+exit 0

--- a/docs/source/components/lower-level/level2/l2ps.rst
+++ b/docs/source/components/lower-level/level2/l2ps.rst
@@ -35,10 +35,16 @@ Note that these images are intended for software development and do not necessar
 If debug output is required, the software needs to be re-compiled, which should only be done by expert users.
 If DEBUG is activated, :ref:`level2-bulk` does not allow you to process multiple images or to use parallel processing (your system will be unresponsive because too much data is simultaneously written to the disc, and parallel calls to force-l2ps would overwrite the debugging images).
 
-For debugging, follow these steps:
+For debugging, follow these steps either with:
 
 1) Modify src/higher-level/const-cl.h
 
 2) In the ‘compiler options’ section, uncomment ``FORCE_DEBUG``.
 
 3) Re-compile the software
+
+Or:
+
+1) Run ./debug.sh
+
+2) Re-compile the software

--- a/docs/source/components/lower-level/level2/l2ps.rst
+++ b/docs/source/components/lower-level/level2/l2ps.rst
@@ -35,16 +35,4 @@ Note that these images are intended for software development and do not necessar
 If debug output is required, the software needs to be re-compiled, which should only be done by expert users.
 If DEBUG is activated, :ref:`level2-bulk` does not allow you to process multiple images or to use parallel processing (your system will be unresponsive because too much data is simultaneously written to the disc, and parallel calls to force-l2ps would overwrite the debugging images).
 
-For debugging, follow these steps either with:
-
-1) Modify src/higher-level/const-cl.h
-
-2) In the ‘compiler options’ section, uncomment ``FORCE_DEBUG``.
-
-3) Re-compile the software
-
-Or:
-
-1) Run ./debug.sh
-
-2) Re-compile the software
+For debugging, follow the steps outlined in the :ref:`install` section.

--- a/docs/source/setup/docker.rst
+++ b/docs/source/setup/docker.rst
@@ -28,9 +28,9 @@ You can use FORCE like this:
 
 Which outputs a default message showing that FORCE works indeed.
 
-On the `Docker hub page <https://hub.docker.com/repository/docker/fegyi001/force/tags?page=1>`_ you can see multiple tags for fegyi001/force. The tags refer to the version first (e.g. v3.0.1), then optionally indicates whether it is a SPLITS version and/or a debug version.
+On the `Docker hub page <https://hub.docker.com/repository/docker/fegyi001/force/tags?page=1>`_ you can see multiple tags for ``fegyi001/force``. The tags refer to the version first (e.g. v3.0.1), then optionally indicates whether it is a SPLITS version and/or a debug version.
 
-E.g. if you wish to use FORCE of version 3.0.1 in debug mode with SPLITS use this image: `fegyi001/force:v3.0.1_splits_debug`
+E.g. if you wish to use FORCE of version 3.0.1 in debug mode with SPLITS use this image: ``fegyi001/force:v3.0.1_splits_debug``
 
 
 Local build

--- a/docs/source/setup/docker.rst
+++ b/docs/source/setup/docker.rst
@@ -28,9 +28,7 @@ You can use FORCE like this:
 
 Which outputs a default message showing that FORCE works indeed.
 
-On the `Docker hub page <https://hub.docker.com/repository/docker/fegyi001/force/tags?page=1>`_ you can see multiple tags for ``fegyi001/force``. The tags refer to the version first (e.g. v3.0.1), then optionally indicates whether it is a SPLITS version and/or a debug version. If you see only the version number this indicates default options (disabled SPLITS & disabled debug mode).
-
-E.g. if you wish to use FORCE of version 3.0.1 in debug mode with SPLITS use this image: ``fegyi001/force:v3.0.1_splits_debug``
+On the `Docker hub page <https://hub.docker.com/repository/docker/fegyi001/force/tags?page=1>`_ you can see multiple tags for ``fegyi001/force``. The tags refer to the version first (e.g. v3.0.1), then optionally indicates whether it is a SPLITS version and/or a debug version. E.g. if you wish to use FORCE of version 3.0.1 in debug mode with SPLITS use this image: ``fegyi001/force:v3.0.1_splits_debug``. If you see only the version number this indicates default options (disabled SPLITS & disabled debug mode). 
 
 
 Local build

--- a/docs/source/setup/docker.rst
+++ b/docs/source/setup/docker.rst
@@ -28,7 +28,7 @@ You can use FORCE like this:
 
 Which outputs a default message showing that FORCE works indeed.
 
-On the `Docker hub page <https://hub.docker.com/repository/docker/fegyi001/force/tags?page=1>`_ you can see multiple tags for ``fegyi001/force``. The tags refer to the version first (e.g. v3.0.1), then optionally indicates whether it is a SPLITS version and/or a debug version.
+On the `Docker hub page <https://hub.docker.com/repository/docker/fegyi001/force/tags?page=1>`_ you can see multiple tags for ``fegyi001/force``. The tags refer to the version first (e.g. v3.0.1), then optionally indicates whether it is a SPLITS version and/or a debug version. If you see only the version number this indicates default options (disabled SPLITS & disabled debug mode).
 
 E.g. if you wish to use FORCE of version 3.0.1 in debug mode with SPLITS use this image: ``fegyi001/force:v3.0.1_splits_debug``
 

--- a/docs/source/setup/docker.rst
+++ b/docs/source/setup/docker.rst
@@ -17,7 +17,7 @@ The easiest way to use FORCE with Docker is to use a prebuilt image pulled from 
   .. code-block:: bash
 
     # This takes only a few minutes
-    docker pull fegyi001/force:latest
+    docker pull fegyi001/force
 
 This downloads the latest, fully featured FORCE (^3.x) on your local machine including SPLITS.
 You can use FORCE like this:
@@ -27,6 +27,10 @@ You can use FORCE like this:
     docker run fegyi001/force force
 
 Which outputs a default message showing that FORCE works indeed.
+
+On the `Docker hub page <https://hub.docker.com/repository/docker/fegyi001/force/tags?page=1>`_ you can see multiple tags for fegyi001/force. The tags refer to the version first (e.g. v3.0.1), then optionally indicates whether it is a SPLITS version and/or a debug version.
+
+E.g. if you wish to use FORCE of version 3.0.1 in debug mode with SPLITS use this image: `fegyi001/force:v3.0.1_splits_debug`
 
 
 Local build
@@ -40,11 +44,24 @@ If you wish to build a Docker image instead of using the prebuilt version you ca
     # The '-t' flag indicates how your local image will be called, in this case 'my-force'
     docker build -t my-force .
 
-If you wish to enable SPLITS run the build with the following command:
+If you wish to enable **SPLITS** run the build with the following command:
 
   .. code-block:: bash
 
     docker build -t my-force --build-arg splits=true .
+
+If you wish to enable **DEBUG** mode run the build with the following command:
+
+  .. code-block:: bash
+
+    docker build -t my-force --build-arg debug=true .
+
+You can add multiple build arguments, e.g. if you wish to enable SPLITS and DEBUG mode run the build with the following command:
+
+  .. code-block:: bash
+
+    docker build -t my-force --build-arg splits=true --build-arg debug=true .
+
 
 After that, you can use your newly built Docker image like this:
 
@@ -60,3 +77,4 @@ The rest is up to you, you can do anything Docker containers support. E.g. you w
     # You map your local folder into /opt/data for your force container
     # Without it FORCE will not be able to see your local files since it is isolated
     docker run -v /my/local/folder:/opt/data my-force force-level2 /opt/data/parameters.prm
+

--- a/docs/source/setup/docker.rst
+++ b/docs/source/setup/docker.rst
@@ -5,8 +5,8 @@ Docker support
 
 If you wish to use FORCE with docker you can do it in two ways: 
 
-* download a prebuilt image from Docker hub
-* create a local build with Dockerfile
+* download a **prebuilt image** from Docker hub
+* create a **local build** with Dockerfile
 
 
 Use prebuilt image

--- a/docs/source/setup/install.rst
+++ b/docs/source/setup/install.rst
@@ -84,13 +84,13 @@ Installation in DEBUG mode
 
 Follow these steps before step 3 in the installation instruction:
 
-b) Enable DEBUG in FORCE
+a) Enable DEBUG in FORCE
 
     .. code-block:: bash
     
       cd ~/src/force
       ./debug.sh enable
 
-c) Proceed with the installation of FORCE
+b) Proceed with the installation of FORCE
 
   

--- a/docs/source/setup/install.rst
+++ b/docs/source/setup/install.rst
@@ -77,5 +77,20 @@ Installation with optional software
        ./splits.sh enable
 
   c) Proceed with the installation of FORCE
-  
+
+
+Installation in DEBUG mode
+--------------------------
+
+Follow these steps before step 3 in the installation instruction:
+
+b) Enable DEBUG in FORCE
+
+    .. code-block:: bash
+    
+      cd ~/src/force
+      ./debug.sh enable
+
+c) Proceed with the installation of FORCE
+
   


### PR DESCRIPTION
Hi David!

I think it would be a nice feature if - just like with SPLITS - debug mode could be enabled/disabled with a script instead of modifying source files.

I created a debug.sh (works the same way as splits.sh). Also included it into the Docker build as another build-arg, and updated the overall documentation wherever it seemed relevant.
