### PR TITLE
Use docker user instead of force-docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ RUN if [ "$splits" = "false" ] ; then ./splits.sh disable; else ./splits.sh enab
   # Conditionally enable DEBUG mode
   if [ "$debug" = "true" ] ; then ./debug.sh enable; else ./debug.sh disable; fi && \
   # Compile FORCE
+  sed -i 's+BINDIR=/develop+BINDIR=/usr/local/bin+' Makefile && \
   make -j7 \
   && make install \
   && make clean
@@ -98,8 +99,9 @@ RUN groupadd docker && \
   useradd -m docker -g docker -p docker && \
   chgrp docker /usr/local/bin/ && \
   chgrp docker /develop
+# Use this user by default
+USER docker
 
-WORKDIR /usr/local/bin
+WORKDIR /home/docker
 
-# In case of develop branch FORCE is installed into /develop folder
-RUN if test -f "/develop/force"; then /develop/force; else force; fi
+RUN force

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,16 +73,19 @@ RUN ./configure CPPFLAGS="-I /usr/include/gdal" CXXFLAGS=-fpermissive \
   && make clean
 
 # Build FORCE from source
-RUN mkdir -p $INSTALL_DIR/force
+RUN mkdir -p $INSTALL_DIR/force && \
+  # This is needed in case of develop branch
+  mkdir -p /develop
 WORKDIR $INSTALL_DIR/force
 COPY . . 
-# Conditionally disable SPLITS which is enabled by default
 ARG splits=true 
-RUN if [ "$splits" = "false" ] ; then ./splits.sh disable; else ./splits.sh enable; fi
-# Conditionally enable DEBUG mode
 ARG debug=false 
-RUN if [ "$debug" = "true" ] ; then ./debug.sh enable; else ./debug.sh disable; fi
-RUN make -j7 \
+# Conditionally disable SPLITS which is enabled by default
+RUN if [ "$splits" = "false" ] ; then ./splits.sh disable; else ./splits.sh enable; fi && \
+  # Conditionally enable DEBUG mode
+  if [ "$debug" = "true" ] ; then ./debug.sh enable; else ./debug.sh disable; fi && \
+  # Compile FORCE
+  make -j7 \
   && make install \
   && make clean
 
@@ -90,12 +93,13 @@ RUN make -j7 \
 RUN rm -rf $INSTALL_DIR
 RUN apt-get purge -y --auto-remove apt-utils cmake git build-essential software-properties-common
 
-# Create a dedicated user for running FORCE commands
-RUN useradd -m force-user -p force && \
-  chown -R force-user /usr/local/bin/
-# Use this user by default
-USER force-user
-WORKDIR /home/force-user
+# Create a dedicated 'docker' group and user for running FORCE commands
+RUN groupadd docker && \
+  useradd -m docker -g docker -p docker && \
+  chgrp docker /usr/local/bin/ && \
+  chgrp docker /develop
 
-# Test FORCE run
-RUN force
+WORKDIR /usr/local/bin
+
+# In case of develop branch FORCE is installed into /develop folder
+RUN if test -f "/develop/force"; then /develop/force; else force; fi

--- a/docs/source/setup/docker.rst
+++ b/docs/source/setup/docker.rst
@@ -90,16 +90,6 @@ If you wish to enter the running container's terminal run it with the ``-it`` fl
   .. code-block:: bash
 
     docker run -it -v /my/local/folder:/opt/data fegyi001/force
-
-It is highly recommended to use the Docker image with docker user. By default Docker uses the ``root`` user which can raise security issues. Therefore it is always advised to run FORCE in Docker with the ``-u`` (or ``--user``) flag like this:
-
-  .. code-block:: bash
-
-    # Uses the logged in user and group
-    docker run -it -u $(id -u):$(id -g) fegyi001/force bash
-
-    # Uses a specific user and group
-    docker run -it -u 1000:1000 fegyi001/force bash
   
 
 User credentials

--- a/docs/source/setup/docker.rst
+++ b/docs/source/setup/docker.rst
@@ -90,6 +90,16 @@ If you wish to enter the running container's terminal run it with the ``-it`` fl
   .. code-block:: bash
 
     docker run -it -v /my/local/folder:/opt/data fegyi001/force
+
+It is highly recommended to use the Docker image with docker user. By default Docker uses the ``root`` user which can raise security issues. Therefore it is always advised to run FORCE in Docker with the ``-u`` (or ``--user``) flag like this:
+
+  .. code-block:: bash
+
+    # Uses the logged in user and group
+    docker run -it -u $(id -u):$(id -g) fegyi001/force bash
+
+    # Uses a specific user and group
+    docker run -it -u 1000:1000 fegyi001/force bash
   
 
 User credentials


### PR DESCRIPTION
In this PR I changed 'force-docker' user to simply 'docker' and also created a group called 'docker' which can call the FORCE binaries. Also updated the doc about preferred usage by setting the user.