### PR TITLE
Reworked error reporting, adding doc for l1-csd

### DIFF
--- a/bash/force-level1-csd.sh
+++ b/bash/force-level1-csd.sh
@@ -42,89 +42,12 @@ done
 
 # ============================================================
 # set up functions
-show_help() {
-cat << HELP
-
-Usage: `basename $0` [optional arguments] metadata-dir level-1-datapool queue aoi
-
-Mandatory arguments:
-
-  metadata-dir
-  Directory where the metadata catalogues (csv file) are stored
-
-  level-1-datapool
-  An existing directory, your files will be stored here
-
-  queue
-  Downloaded files are appended to a file queue, which is needed for the 
-  Level 2 processing. The file doesn't need to exist. If it does exist,
-  new lines will be appended on successful ingestion
-
-  area of interest
-  (1) user-supplied coordinates of your study area: 
-      The polygon must be closed (first X/Y = last X/Y). X/Y must be given as
-      decimal degrees with negative values for West and South coordinates.
-      Either specify the path to a file, or the coordinates on the command line.
-      If in a file, provide one coordinate per line.
-      If on the command line, provide a comma separated list.
-  (2) a shapefile (point/polygon/line). On-the-fly reprojection is provided,
-      but using EPSG4326 is recommended.
-  (3) scene identifier:
-      Landsat: Path/Row as "PPPRRR". Make sure to keep leading zeros:
-        correct: 181034, incorrect: 18134
-      Sentinel-2: MGRS tile as "TXXXXX". Make sure to keep the leading T before 
-        the MGRS tile number.
-      You can either give the path to a file, or give the IDs on the command line.
-      If in a file, provide one ID per line.
-      If on the command line, provide a comma separated list.
-  
-Optional arguments:
-
-  -h | --help
-  Show this help
-  
-  -c | --cloudcover
-  minimum,maximum
-  The cloud cover range must be specified in %
-  Default: 0,100
-  
-  -d | --daterange
-  starttime,endtime
-  Dates must be given in the following format: YYYYMMDD,YYYYMMDD
-  Default: 19700101,today
-  
-  -n | --no-act
-  Will trigger a dry run that will only return the number of images
-  and their total data volume
-  
-  -k | --keep-meta
-  Will write the results of the query to the level 1 datapool directory.
-  Two files will be created if Landsat and Sentinel-2 data is queried
-  at the same time. Filename: csd_metadata_YYYY-MM-DDTHH-MM-SS
-  
-  -s | --sensor
-  Sensors to include in the query, comma-separated.
-  Valid sensors:
-  Landsat                             Sentinel
-  LT04 - Landsat 4 TM                 S2A - Sentinel-2A MSI
-  LT05 - Landsat 5 TM                 S2B - Sentinel-2B MSI
-  LE07 - Landsat 7 ETM+               
-  LC08 - Landsat 8 OLI
-  Default: LT04,LT05,LE07,LC08,S2A,S2B
-  
-  -t | --tier
-  Landsat collection tier level. Valid tiers: T1,T2,RT
-  Default: T1
-  
-  -u | --update
-  Will update the metadata catalogue (download and extract from GCS)
-  If this option is used, only one mandatory argument is expected (metadata-dir).
-  Use the -s option to only update Landsat or Sentinel-2 metadata.
-    
-HELP
-exit 1
+check_params() {
+  # make sure we have two comma-separated arguments to optional params
+  if ! echo "$1" | grep -q ","; then show_help "$(printf "%s\n       " "Only one ""$2"" specified or ""$2""s not separated by comma")"; fi
+  local secondarg=$(echo "$1" | cut -d"," -f2)
+  if ! [ -n $secondarg ]; then show_help "$(printf "%s\n       " "Only one ""$2"" specified." "Provide exactly two arguments separated by a comma ,")"; fi
 }
-
 
 is_in_range() {
   awk -v value="$1" -v lower="$2" -v upper="$3" 'BEGIN {print (lower <= value && value <= upper)}'
@@ -137,6 +60,22 @@ is_smaller() {
 round() { 
   local valmult=$(awk -v val="$1" -v digits="$2" 'BEGIN {print (val * 10^digits)}')
   awk -v val="$valmult" -v digits="$2" 'BEGIN {print (int(val+0.5)) / 10^digits}'
+}
+
+show_help() {
+cat << HELP
+
+force-level1-csd - FORCE cloud storage downloader for Landsat and Sentinel-2
+https://force-eo.readthedocs.io/en/latest/components/lower-level/level1/level1-csd.html
+
+Usage: force-level1-csd [-c min,max] [-d starttime,endtime] [-n] [-k] [-s sensor]
+                        [-t tier] [-u]
+                        metadata-dir level-1-datapool queue aoi
+
+Error: `printf "$1"`
+HELP
+
+exit 1
 }
 
 show_progress() {
@@ -157,6 +96,7 @@ update_meta() {
 }
 
 which_satellite() {
+  # set SENTINEL and LANDSAT flags and check if sensor names are valid
   SENSIN=$(echo $SENSIN | tr '[:lower:]' '[:upper:]')  # convert sensor strings to upper case to prevent unnecessary headaches
   for SENSOR in $(echo $SENSIN | sed 's/,/ /g'); do
     case $SENSOR in
@@ -165,7 +105,7 @@ which_satellite() {
       LT04|LT05|LE07|LC08)
         LANDSAT=1 ;;
       *)
-        printf "%s\n" "" "Error: invalid sensor(s) specified" "Sensors provided: $SENSIN" "Valid sensors: S2A,S2B,LT04,LT05,LE07,LC08" ""
+        show_help "$(printf "%s\n       " "Invalid sensor(s) specified" "Sensors provided: $SENSIN" "Valid sensors: S2A,S2B,LT04,LT05,LE07,LC08")"
         exit 1
     esac
   done
@@ -186,28 +126,28 @@ SENTINEL=0
 UPDATE=0
 KEEPMETA=0
 
-# change - to %dummy% if followed by integer: prevent interpretation as option by getopt
+# Negative coordinates: change ( -) to %dummy% if followed by integer: prevent interpretation as option by getopt
 ARGS=$(echo "$@" | sed -E "s/ -([0-9])/ %dummy%\1/g")
 set -- $ARGS
 
-ARGS=`getopt -o c:d:nhks:t:u -l cloudcover:,daterange:,no-act,help,keep-meta,sensors:,tier:,update -n $0 -- "$@"`
-if [ $? != 0 ] ; then  printf "%s\n" "" "Error in command line options. Please check your options." >&2 ; show_help ; fi
+ARGS=`getopt -o c:d:nks:t:u -l cloudcover:,daterange:,no-act,keep-meta,sensors:,tier:,update -n $0 -- "$@"`
+if [ $? != 0 ] ; then show_help "$(printf "%s\n       " "Error in command line options. Please check your options.")"; fi
 eval set -- "$ARGS"
 
 while :; do
   case "$1" in
     -c|--cloudcover)
+      check_params "$2" "cloud cover threshold"
       CCMIN=$(echo "$2" | cut -d"," -f1)
       CCMAX=$(echo "$2" | cut -d"," -f2)
       shift ;;
     -d|--daterange)
+      check_params "$2" "date"
       DATEMIN=$(echo "$2" | cut -d"," -f1)
       DATEMAX=$(echo "$2" | cut -d"," -f2)
       shift ;;
     -n|--no-act)
       DRYRUN=1 ;;
-    -h|--help)
-      show_help ;;
     -k|--keep-meta)
       KEEPMETA=1 ;;
     -s|--sensors)
@@ -235,17 +175,13 @@ eval set -- "$ARGS"
 if [ $UPDATE -eq 1 ]; then
   METADIR="$1"
   if [ $# -lt  1 ]; then
-    printf "%s\n" "" "Metadata directory not specified, exiting" ""
-    exit 1
+    show_help "$(printf "%s\n       " "Metadata directory not specified")"
   elif [ $# -gt 1 ]; then
-    printf "%s\n" "" "Error: Too many arguments." "Only specify the metadata directory when using the update option (-u)." "The only allowed optional argument is -s. Use it if you would like" "to only update either the Landsat or Sentinel-2 metadata catalogue." ""
-    exit 1
+    show_help "$(printf "%s\n       " "Too many arguments." "Only specify the metadata directory when using the update option (-u)." "The only allowed optional argument is -s. Use it if you would like to only" "update either the Landsat or Sentinel-2 metadata catalogue.")"
   elif ! [ -w $METADIR ]; then
-    printf "%s\n" "" "Metadata directory does not exist, exiting" ""
-    exit 1
+    show_help "$(printf "%s\n       " "Metadata directory does not exist, exiting")"
   elif ! [ -w $METADIR ]; then
-    printf "%s\n" "" "Can not write to metadata directory, exiting" ""
-    exit 1
+    show_help "$(printf "%s\n       " "Can not write to metadata directory, exiting")"
   else
     which_satellite
     if [ $LANDSAT -eq 1 ]; then
@@ -261,8 +197,7 @@ fi
 
 # check if number of mandatory args is correct
 if [ $# -ne 4 ]; then
-  printf "%s\n" "" "Incorrect number of mandatory input arguments provided" "Expected: 4 Received: $#: $(echo "$@" | sed 's/ /,/g')"
-  show_help
+  show_help "$(printf "%s\n       " "Incorrect number of mandatory input arguments provided" "Expected: 4 Received: $#: $(echo "$@" | sed 's/ /,/g')")"
 fi
 
 which_satellite
@@ -276,8 +211,7 @@ AOI="$4"
 
 # check for empty arguments
 if [[ -z $METADIR || -z $POOL || -z $QUEUE || -z $AOI || -z $CCMIN || -z $CCMAX || -z $DATEMIN || -z $DATEMAX || -z $SENSIN || -z $TIER ]]; then
-  printf "%s\n" "" "Error: One or more arguments are undefined, please check the following" "" "Metadata directory: $METADIR" "Level-1 pool: $POOL" "Queue: $QUEUE" "AOI: $AOI" "Sensors: $SENSIN" "Start date: $DATEMIN, End date: $DATEMAX" "Cloud cover minimum: $CCMIN, cloud cover maximum: $CCMAX" "Tier (Landsat only): $TIER" ""
-  exit 1
+  show_help "$(printf "%s\n       " "One or more arguments are undefined, please check the following" "" "Metadata directory: $METADIR" "Level-1 pool: $POOL" "Queue: $QUEUE" "AOI: $AOI" "Sensors: $SENSIN" "Start date: $DATEMIN, End date: $DATEMAX" "Cloud cover minimum: $CCMIN, cloud cover maximum: $CCMAX" "Tier (Landsat only): $TIER")"
 fi
 
 # check for correct tier
@@ -286,50 +220,50 @@ for T in $(echo $TIER | sed 's/,/ /g'); do
     T1|T2|RT)
       true ;;
     *)
-      printf "%s\n" "Error: Invalid tier specified. Valid tiers: T1,T2,RT" ""
-      exit 1 ;;
+      show_help "$(printf "%s\n       " "Invalid tier specified. Valid tiers: T1,T2,RT")" ;;
    esac
 done
 
 # check if dates are correct
 if ! [[ $DATEMIN =~ ^[[:digit:]]+$ ]] || ! [[ $DATEMAX  =~ ^[[:digit:]]+$ ]]; then
-  printf "%s\n" "" "Error: One of the entered dates seems to contain non-numeric characters." "Start: $DATEMIN, End: $DATEMAX" ""
-  exit 1
+  show_help "$(printf "%s\n       " "Entered dates seem to contain non-numeric characters." "Start: $DATEMIN, End: $DATEMAX")"
 elif ! date -d $DATEMIN &> /dev/null || ! [ ${#DATEMIN} -eq 8 ]; then
-  printf "%s\n" "" "Starttime ($DATEMIN) is not a valid date." "Make sure dates are formatted as YYYYMMDD" ""
-  exit 1
+  show_help "$(printf "%s\n       " "Starttime ($DATEMIN) is not a valid date." "Make sure dates are formatted as YYYYMMDD")"
 elif ! date -d $DATEMAX &> /dev/null || ! [ ${#DATEMAX} -eq 8 ]; then
-    printf "%s\n" "" "Endtime ($DATEMAX) is not a valid date." "Make sure dates are formatted as YYYYMMDD" ""
-  exit 1
+  show_help "$(printf "%s\n       " "Endtime ($DATEMAX) is not a valid date." "Make sure dates are formatted as YYYYMMDD")"
 elif [ $(date -d $DATEMIN +%s) -gt $(date -d $DATEMAX +%s) ]; then
-  printf "%s\n" "Error: Start of date range is larger than end of date range" "Start: $DATEMIN, End: $DATEMAX" ""
-  exit 1
+  show_help "$(printf "%s\n       " "Start of date is larger than end date." "Start: $DATEMIN, End: $DATEMAX")"
 fi
 
 # check if cloud cover is valid
 if [ $(is_smaller $CCMIN 0) -eq 1 ] || [ $(is_smaller 100 $CCMIN) -eq 1 ] || [ $(is_smaller $CCMAX 0) -eq 1 ] || [ $(is_smaller 100 $CCMAX ) -eq 1 ]; then
-  printf "%s\n" "" "Error: Cloud cover minimum and maximum must be specified between 0 and 100" "Cloud cover minimum: $CCMIN" "Cloud cover maximum: $CCMAX" ""
-  exit 1
+  show_help "$(printf "%s\n       " "Cloud cover minimum and maximum must be specified between 0 and 100" "Cloud cover minimum: $CCMIN" "Cloud cover maximum: $CCMAX")"
   elif [ $(is_smaller $CCMAX $CCMIN) -eq 1 ]; then
-    printf "%s\n" "" "Error: Cloud cover minimum is larger than cloud cover maximum" "Cloud cover minimum: $CCMIN" "Cloud cover maximum: $CCMAX" ""
-    exit 1
+    show_help "$(printf "%s\n       " "Cloud cover minimum is larger than cloud cover maximum" "Cloud cover minimum: $CCMIN" "Cloud cover maximum: $CCMAX")"
 fi
 
+# ======================================
 # check type of AOI
 # 1 - shapefile
 # 2 - coordinates as text
 # 3 - PathRow as text
+
+# Is AOI a file?
 if [ -f $AOI ]; then
-  # check if AOI is GDAL readable file
+  # is AOI a GDAL readable file?
   if ogrinfo $AOI >& /dev/null; then
     AOITYPE=1
     OGR=1
   else
-    # check if tile list / bounding box file contains whitespaces
+    # Must be tile list or bounding box
+    # check if tile list / bounding box file contains whitespaces or non-unix eol
     if grep -q " " $AOI; then
-      printf "%s\n" "Error: whitespace in AOI definition detected." "Please make sure this file uses Linux style end of lines and does not contain whitespaces." ""
-      exit 1
+      show_help "$(printf "%s\n       " "Whitespace in AOI definition detected." "Please make sure this file does not contain whitespace.")"
+    elif
+      grep -U -q $'\015' $AOI; then
+        show_help "$(printf "%s\n       " "AOI file seems to contain CR characters." "Did you create this file under Windows/MacOS?" "Please make sure this file uses UNIX end of line (LF) and does not contain whitespace.")"
     fi
+    
     AOI=$(cat $AOI | sed 's/,/./g')
     OGR=0
   fi
@@ -346,18 +280,15 @@ if [ $OGR -eq 0 ]; then
     # are coords valid lat/lon?
     for COORD in $AOI; do
       if ! $(echo $COORD | grep -q "/"); then
-        printf  "%s\n" "Error: At least one of the AOI coordinates does not seem to be separated by a forward slash /" "Coordinate: $COORD" ""
-        exit 1
+        show_help "$(printf "%s\n       " "At least one of the AOI coordinates does not seem to be separated by a forward slash /" "Coordinate: $COORD")"
       fi
       LAT=$(echo $COORD | cut -d"/" -f1)
       LON=$(echo $COORD | cut -d"/" -f2)
 
       if ! [ $(is_in_range $LAT -90 90) -eq 1 ]; then
-        printf "%s\n" "Error: Latitude out of range" "Coordinate: $COORD - $LAT is not in range -90 to 90" "This error may also mean that you tried to use a vector file as AOI but provided an incorrect path" ""
-        exit 1
+        show_help "$(printf "%s\n       " "Latitude out of range" "Coordinate: $COORD - $LAT is not in range -90 to 90" "This error may also mean that you tried to use a vector file as AOI but provided an incorrect path")"
       elif ! [ $(is_in_range $LON -180 180) -eq 1 ]; then
-        printf "%s\n" "Error: Longitute out of range" "Coordinate: $COORD - $LON is not in range -180 to 180" ""
-        exit 1
+        show_help "$(printf "%s\n       " "Longitute out of range" "Coordinate: $COORD - $LON is not in range -180 to 180")"
       fi
     done
   # else, AOI input must be tile list - check if tiles are valid Path/Row or S2 tiles
@@ -369,22 +300,18 @@ if [ $OGR -eq 0 ]; then
         LSPATH="${ENTRY:0:3}"
         LSROW="${ENTRY:3:6}"
         if [ $(is_in_range $LSPATH 1 233) -eq 0 ] || [ $(is_in_range $LSPATH 1 248) -eq 0 ]; then
-          printf "%s\n" "" "Landsat PATH / ROW out of range. PATH not in range 1 to 233 or ROW not in range 1 to 248." "PATH / ROW received: $ENTRY" ""
-          exit 1
+          show_help "$(printf "%s\n       " "Landsat PATH / ROW out of range. PATH not in range 1 to 233 or ROW not in range 1 to 248." "PATH / ROW received: $ENTRY")"
         fi
         continue
-      elif $(echo $ENTRY | grep -q -E "T[0-6][0-9][A-Z]{3}"); then
-        if ! [ $(is_in_range ${ENTRY:2:3} 1 60) ]; then
-          printf "%s\n" "" "MGRS tile number out of range. Valid range: 0 to 60, received: $ENTRY" ""
-          exit 1
+      elif $(echo $ENTRY | grep -q -E "T[0-9]{2}[A-Z]{3}"); then
+        if [ $(is_in_range "${ENTRY:1:2}" 1 60) -eq 0 ]; then
+          show_help "$(printf "%s\n       " "MGRS tile number out of range." "Valid range: 0 to 60, received: $ENTRY")"
         elif [[ -z "$(echo ${ENTRY:3:1} | grep -E "[C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,T,U,V,W,X]")" || -z "$(echo ${ENTRY:4:1} | grep -E "[A,B,C,D,E,F,G,H,K,L,M,N,P,Q,R,T,U,V,W,X,Y,Z]")" || -z "$(echo ${ENTRY:5:1} | grep -E "[A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,T,U,V]")" ]]; then
-          printf "%s\n" "" "Tile does not seem to be a valid Sentinel-2 tile: $ENTRY" "Please make sure all tiles exist." ""
-          exit 1
+          show_help "$(printf "%s\n       " "Tile does not seem to be a valid Sentinel-2 tile: $ENTRY" "Please make sure all tiles exist.")"
         fi
         continue
       else
-        printf "%s\n" "" "Tile list as AOI detected." "" "Error: One or more tiles seem to be formatted incorrectly." "Please check $ENTRY" "If you are trying to define an AOI using coordinates, makes sure X and Y are separated using a forward slash /"
-        exit 1
+        show_help "$(printf "%s\n       " "Tile list as AOI detected." "One or more tiles seem to be formatted incorrectly." "Please check $ENTRY" "If you are trying to define an AOI using coordinates, makes sure X and Y are separated using a forward slash /")"
       fi
     done
   fi
@@ -410,13 +337,13 @@ get_data() {
   # Check if metadata catalogue exists and is up to date
   METACAT=$METADIR"/metadata_$SATELLITE.csv"
   if ! [ -f $METACAT ]; then
-    printf "%s\n" "" "$METACAT: Metadata catalogue does not exist. Use the -u option to download / update the metadata catalogue" ""
+    printf "%s\n" "" "Error: $METACAT: Metadata catalogue does not exist." "Use the -u option to download / update the metadata catalogue" ""
     exit 1
   fi
 
   METADATE=$(date -d $(stat $METACAT | grep "Change: " | cut -d" " -f2) +%s)
   if [ $(date -d $DATEMAX +%s) -gt $METADATE ]; then
-    printf "%s\n" "" "WARNING: The selected time window exceeds the last update of the $PRINTNAME metadata catalogue." "Results may be incomplete, please consider updating the metadata catalogue using the -d option."
+    printf "%s\n" "" "WARNING: The selected time window exceeds the last update of the $PRINTNAME metadata catalogue." "Results may be incomplete, please consider updating the metadata catalogue using the -u option."
   fi
 
   if [ "$AOITYPE" -eq 1 ]; then
@@ -507,7 +434,6 @@ get_data() {
   if [ -z $NSCENES ];then
     printf "%s\n" "There were no $PRINTNAME Level 1 scenes found matching the search criteria." ""
   else
-    #LC_NUMERIC="en_US.UTF-8" printf "%s\n%.2f%s\n" "$NSCENES $PRINTNAME Level 1 scenes matching criteria found" "$PRSIZE" "$UNIT data volume found."
     printf "%s\n" "$NSCENES $PRINTNAME Level 1 scenes matching criteria found" "$PRSIZE$UNIT data volume found."
   fi
 

--- a/docs/source/components/lower-level/level1/level1-csd.rst
+++ b/docs/source/components/lower-level/level1/level1-csd.rst
@@ -9,7 +9,7 @@ FORCE can download Landsat and Sentinel-2 data from cloud storage providers (cur
 
 .. note::
 
-    If you need to bypass ``force-level1-sentinel2``, it is recommended to store the images in a consistent data pool without duplicates.
+    If you need to bypass ``force-level1-csd``, it is recommended to store the images in a consistent data pool without duplicates.
     You will need to prepare a :ref:`queue`.
 
 
@@ -132,3 +132,4 @@ The remaining optional arguments are used to perform a search without actually d
 
     To learn more about FORCE Level 1 CSD, check the `tutorial <https://davidfrantz.github.io/tutorials/force-level1-csd>`_.
     It covers the set up, usage, and provides some more general information.
+

--- a/docs/source/components/lower-level/level1/level1-csd.rst
+++ b/docs/source/components/lower-level/level1/level1-csd.rst
@@ -3,5 +3,132 @@
 force-level1-csd
 ================
 
-Usage to follow.
+FORCE can download Landsat and Sentinel-2 data from cloud storage providers (currently Google Cloud Storage).
 
+``force-level1-csd`` allows to search for image acquisitions that precisely match the user's requirements, manages data pool, and prepares/updates the file queue required for level 2 procesing.
+
+.. note::
+
+    If you need to bypass ``force-level1-sentinel2``, it is recommended to store the images in a consistent data pool without duplicates.
+    You will need to prepare a :ref:`queue`.
+
+
+Usage
+"""""
+
+.. note::
+
+    Before you start:
+    The metadata catalogues need to be downloaded prior to the first run and downloading Sentinel-2 data requires authentication.
+    See the `tutorial <https://davidfrantz.github.io/tutorials/force-level1-csd>`_ for more information on properly setting up ``force-level1-csd``.
+
+
+``force-level1-csd`` requires four mandatory arguments to be specified.
+Several optional arguments can be used to further refine the search.
+
+.. code-block:: none
+
+    Usage: force-level1-csd [optional arguments] metadata-dir level-1-datapool queue aoi
+
+
+* **metadata-dir**
+
+    | The directory where the metadata catalogues (csv files) are stored.
+    | They need to be downloaded before the first use and should be updated regularly.
+
+* **level-1-datapool**
+
+    | All downloaded files are stored in the data pool, which should be an existing directory.
+    | Scenes will not be downloaded if they already exist in this folder.
+
+* **queue**
+
+    | Downloaded files are appended to a file queue, which is needed for the Level 2 processing.
+    | The file doesn't need to exist.
+    | If it does exist, new lines will be appended on successful ingestion.
+    | This queue is needed for Level 2 processing.
+    | All images with ``QUEUED`` status will be processed, then set to ``DONE``.
+
+* **area of interest**
+
+    | The area that data should be downloaded for. It can be defined in three different ways
+    | (1) user-supplied coordinates of your study area:
+    |     The polygon must be closed (first ``X/Y`` = last ``X/Y``). ``X/Y`` must be given as
+    |     decimal degrees with negative values for West and South coordinates.
+    |     Either specify the path to a file, or the coordinates on the command line.
+    |     If in a file, provide one coordinate per line.
+    |     If on the command line, provide a comma separated list.
+    | (2) a shapefile (point/polygon/line). On-the-fly reprojection is provided,
+    |     but using EPSG4326 is recommended.
+    | (3) scene identifier:
+    |     Landsat: Path/Row as ``PPPRRR``. Make sure to keep leading zeros:
+    |       correct: 181034, incorrect: 18134
+    |     Sentinel-2: MGRS tile as ``TXXXXX``. Make sure to keep the leading ``T``
+    |       before the MGRS tile number.
+    |     You can either give the path to a file, or give the IDs on the command line.
+    |     If in a file, provide one ID per line.
+    |     If on the command line, provide a comma separated list.
+
+
+
+Running the search without any optional parameters will return all Landsat and Sentinel-2 scenes for the specified ``aoi``.
+To narrow down the search results, use the following parameters.
+
+* **-c | \--cloudcover**
+    | ``minimum,maximum``
+    | The cloud cover range must be specified in %
+    | Default: ``0,100``
+
+* -d | \--daterange
+    | ``starttime,endtime``
+    | Dates must be given in the following format: YYYYMMDD,YYYYMMDD
+    | Default: ``19700101,today``
+
+* **-s | \--sensor**
+    | Sensors to include in the query, comma-separated.
+    | Valid sensors:
+    | Landsat
+    | ``LT04`` - Landsat 4 TM
+    | ``LT05`` - Landsat 5 TM
+    | ``LE07`` - Landsat 7 ETM+
+    | ``LC08`` - Landsat 8 OLI
+    | Sentinel
+    | ``S2A`` - Sentinel-2A MSI
+    | ``S2B`` - Sentinel-2B MSI
+    | Default: ``LT04,LT05,LE07,LC08,S2A,S2B``
+
+* **-t | \--tier**
+    | Landsat collection tier level. Valid tiers: ``T1,T2,RT``
+    | Default: ``T1``
+
+
+The remaining optional arguments are used to perform a search without actually downloading data, store the metadata of search results, and download / update the metadata catalogues.
+
+* **-n | \--no-act**
+    | Will trigger a dry run that will only return the number of images
+    | and their total data volume
+
+* **-k | \--keep-meta**
+    | Will write the results of the query to the level 1 datapool directory.
+    | Two files will be created if Landsat and Sentinel-2 data is queried
+    | at the same time. Filename: ``csd_metadata_[satellite]_YYYY-MM-DDTHH-MM-SS``
+    | ``[satellite]`` refers to either Landsat or Sentinel-2.
+
+* **-u | \--update**
+    | Will create or the metadata catalogue (download and extract from GCS)
+    | If this option is used, only one mandatory argument is expected (metadata-dir).
+    | Use the -s option to only update Landsat or Sentinel-2 metadata.
+
+.. note::
+
+    The mandatory arguments are positional!
+    They need to be provided in this exact order.
+    The optional arguments can be placed anywhere and may also be combined.
+    For example, ``-n -k -c 0,70`` could also be written as ``-nkc 0,70``.
+    When values are passed to the optional arguments (cloud cover, date range, sensor, or tier), these must be separated by commas ``,`` and must not contain whitespace.
+
+
+.. seealso::
+
+    To learn more about FORCE Level 1 CSD, check the `tutorial <https://davidfrantz.github.io/tutorials/force-level1-csd>`_.
+    It covers the set up, usage, and provides some more general information.


### PR DESCRIPTION
- errors are now reported without printing help
- usage + link to docs + error are now printed when level1-csd encounters an error
- -h | --help has been removed

- doc for level1-csd added