### PR TITLE
Fix for #48 and #49, minor improvements to force-level1-csd

### DIFF
--- a/bash/force-level1-csd.sh
+++ b/bash/force-level1-csd.sh
@@ -178,9 +178,9 @@ if [ $UPDATE -eq 1 ]; then
     show_help "$(printf "%s\n       " "Metadata directory not specified")"
   elif [ $# -gt 1 ]; then
     show_help "$(printf "%s\n       " "Too many arguments." "Only specify the metadata directory when using the update option (-u)." "The only allowed optional argument is -s. Use it if you would like to only" "update either the Landsat or Sentinel-2 metadata catalogue.")"
-  elif ! [ -w $METADIR ]; then
+  elif ! [ -w "$METADIR" ]; then
     show_help "$(printf "%s\n       " "Metadata directory does not exist, exiting")"
-  elif ! [ -w $METADIR ]; then
+  elif ! [ -w "$METADIR" ]; then
     show_help "$(printf "%s\n       " "Can not write to metadata directory, exiting")"
   else
     which_satellite
@@ -240,6 +240,11 @@ if [ $(is_smaller $CCMIN 0) -eq 1 ] || [ $(is_smaller 100 $CCMIN) -eq 1 ] || [ $
   show_help "$(printf "%s\n       " "Cloud cover minimum and maximum must be specified between 0 and 100" "Cloud cover minimum: $CCMIN" "Cloud cover maximum: $CCMAX")"
   elif [ $(is_smaller $CCMAX $CCMIN) -eq 1 ]; then
     show_help "$(printf "%s\n       " "Cloud cover minimum is larger than cloud cover maximum" "Cloud cover minimum: $CCMIN" "Cloud cover maximum: $CCMAX")"
+fi
+
+# check if POOL folder exists and is writeable
+if [ ! -w "$POOL" ]; then
+  show_help "$(printf "%s\n       " "Level 1 datapool folder does not exist or is not writeable.")"
 fi
 
 # ======================================
@@ -335,30 +340,34 @@ get_data() {
 
   # ============================================================
   # Check if metadata catalogue exists and is up to date
-  METACAT=$METADIR"/metadata_$SATELLITE.csv"
+  METACAT="$METADIR/metadata_$SATELLITE.csv"
   if ! [ -f $METACAT ]; then
     printf "%s\n" "" "Error: $METACAT: Metadata catalogue does not exist." "Use the -u option to download / update the metadata catalogue" ""
     exit 1
   fi
 
-  METADATE=$(date -d $(stat $METACAT | grep "Change: " | cut -d" " -f2) +%s)
+  METADATE=$(date -r "$METACAT" +%s)
   if [ $(date -d $DATEMAX +%s) -gt $METADATE ]; then
     printf "%s\n" "" "WARNING: The selected time window exceeds the last update of the $PRINTNAME metadata catalogue." "Results may be incomplete, please consider updating the metadata catalogue using the -u option."
   fi
 
   if [ "$AOITYPE" -eq 1 ]; then
     printf "%s\n" "" "Searching for footprints / tiles intersecting with geometries of AOI shapefile..."
-    AOINE=$(echo $(basename "$AOI") | rev | cut -d"." -f 2- | rev)
-    BBOX=$(ogrinfo -so $AOI $AOINE | grep "Extent: " | sed 's/Extent: //; s/(//g; s/)//g; s/, /,/g; s/ - /,/')
+    OGRTEMP="$POOL"/l1csd-temp_$(date +%FT%H-%M-%S)
+    mkdir "$OGRTEMP"
+    # get first layer of vector file and reproject to epsg4326
+    AOILAYER=$(ogrinfo "$AOI" | grep "1: " | sed "s/1: //; s/ ([[:alnum:]]*.*)//")
+    AOIREPRO="$OGRTEMP"/aoi_reprojected.shp
+    ogr2ogr -t_srs EPSG:4326 -f "ESRI Shapefile" "$AOIREPRO" "$AOI"
+    # get ls/s2 tiles intersecting with bounding box of AOI
+    BBOX=$(ogrinfo -so "$AOIREPRO" "$AOILAYER" | grep "Extent: " | sed 's/Extent: //; s/(//g; s/)//g; s/, /,/g; s/ - /,/')
     WFSURL="http://ows.geo.hu-berlin.de/cgi-bin/qgis_mapserv.fcgi?MAP=/owsprojects/grids.qgs&SERVICE=WFS&REQUEST=GetCapabilities&typename="$SATELLITE"&bbox="$BBOX
-
-    ogr2ogr -f "GPKG" merged.gpkg WFS:"$WFSURL" -append -update
-    ogr2ogr -f "GPKG" merged.gpkg $AOI -append -update
-
+    ogr2ogr -f "ESRI Shapefile" "$OGRTEMP"/$SATELLITE.shp WFS:"$WFSURL" -append -update
+    # intersect AOI and tiles
     # remove duplicate entries resulting from multiple features in same tiles: | xargs -n 1 | sort -u | xargs | 
-    TILERAW=$(ogr2ogr -f CSV /vsistdout/ -dialect sqlite -sql "SELECT $SATELLITE.PRFID FROM $SATELLITE, $AOINE WHERE ST_Intersects($SATELLITE.geom, ST_Transform($AOINE.geom, 4326))" merged.gpkg | xargs -n 1 | sort -u | xargs)
-    rm merged.gpkg
-    TILES="_"$(echo $TILERAW | sed 's/PRFID, //; s/ /_|_/g')"_"
+    TILERAW=$(ogr2ogr -f CSV /vsistdout/ -dialect sqlite -sql "SELECT $SATELLITE.PRFID FROM $SATELLITE, aoi_reprojected WHERE ST_Intersects($SATELLITE.geometry, aoi_reprojected.geometry)" "$OGRTEMP" | xargs -n 1 | sort -u | xargs | sed 's/PRFID,//')
+    TILES="_"$(echo $TILERAW | sed 's/ /_|_/g')"_"
+    rm -rf "$OGRTEMP"
     
   elif [ "$AOITYPE" -eq 2 ]; then
     printf "%s\n" "" "Searching for footprints / tiles intersecting with input geometry..."
@@ -398,7 +407,7 @@ get_data() {
     LINKS=$(grep -E $TILES $METACAT | grep -E $(echo ""$SENSORS"" | sed 's/ /_|/g')"_" | grep -E $(echo "_"$TIER | sed 's/,/,|_/g')"," | awk -F "," '{OFS=","} {gsub("-","",$5)}1' | awk -v start="$DATEMIN" -v stop="$DATEMAX" -v clow="$CCMIN" -v chigh="$CCMAX" -F "," '$5 >= start && $5 <= stop && $6 == 01 && $12 >= clow && $12 <= chigh' | sort -t"," -k 5)
   fi
 
-  METAFNAME=$POOL/csd_metadata_$(date +%FT%H-%M-%S).txt
+  METAFNAME="$POOL"/csd_metadata_$(date +%FT%H-%M-%S).txt
   printf "%s" "$LINKS" > $METAFNAME
   case $SATELLITE in
     sentinel2) TOTALSIZE=$(printf "%s" "$LINKS" | awk -F "," '{s+=$6/1048576} END {printf "%f", s}') ;;
@@ -444,7 +453,7 @@ get_data() {
   SIZEDONE=0
   if [[ $DRYRUN -eq 0 && ! -z $LINKS ]]; then
 
-    POOL=$(cd $POOL; pwd)
+    POOL=$(cd "$POOL"; pwd)
     printf "%s\n" "" "Starting to download "$NSCENES" "$PRINTNAME" Level 1 scenes" "" "" "" "" ""
     
     ITER=1
@@ -465,17 +474,17 @@ get_data() {
       
       show_progress
       
-      TILEPATH=$POOL/$TILE    
-      SCENEPATH=$TILEPATH/$SCENEID
+      TILEPATH="$POOL"/$TILE
+      SCENEPATH="$TILEPATH"/$SCENEID
       if [ $SATELLITE = "sentinel2" ]; then
         if [[ $SCENEID == *"_OPER_"* ]]; then
           SCENEID=$(echo $URL | rev | cut -d"/" -f1 | rev | cut -d"." -f1)
         fi
-        SCENEPATH=$TILEPATH/$SCENEID".SAFE"
+        SCENEPATH="$TILEPATH"/$SCENEID".SAFE"
       fi
       # Check if scene already exists, download anyway if gsutil temp files are present
-      if [ -d $SCENEPATH ]; then
-        if ! ls -R $SCENEPATH | grep -q ".gstmp" && ! [ -z "$(ls -A $SCENEPATH)" ]; then
+      if [ -d "$SCENEPATH" ]; then
+        if ! ls -R "$SCENEPATH" | grep -q ".gstmp" && ! [ -z "$(ls -A $SCENEPATH)" ]; then
           printf "\e[500D\e[4A\e[2KScene "$SCENEID"("$ITER" of "$NSCENES") exists, skipping...\e[4B"
           
           ((ITER++))
@@ -484,16 +493,16 @@ get_data() {
       fi
       
       # create target directory if it doesn't exist
-      if [ ! -w $TILEPATH ]; then
-        mkdir $TILEPATH
-        if [ ! -w $TILEPATH ]; then
+      if [ ! -w "$TILEPATH" ]; then
+        mkdir "$TILEPATH"
+        if [ ! -w "$TILEPATH" ]; then
           printf "%s\n" "" "$TILEPATH: Creating directory failed." ""
           exit 1
         fi
       fi
 
       printf "\e[500D\e[2A\e[2KDownloading "$SCENEID"("$ITER" of "$NSCENES")...\e[2B"
-      gsutil -m -q cp -R $URL $TILEPATH
+      gsutil -m -q cp -R $URL "$TILEPATH"
 
       lockfile-create $QUEUE
       echo "$SCENEPATH QUEUED" >> $QUEUE

--- a/docs/source/components/lower-level/level1/level1-csd.rst
+++ b/docs/source/components/lower-level/level1/level1-csd.rst
@@ -20,7 +20,7 @@ Usage
 
     Before you start:
     The metadata catalogues need to be downloaded prior to the first run and downloading Sentinel-2 data requires authentication.
-    See the `tutorial <https://davidfrantz.github.io/tutorials/force-level1-csd>`_ for more information on properly setting up ``force-level1-csd``.
+    See the :ref:`tut-l1csd` tutorial for more information on properly setting up ``force-level1-csd``.
 
 
 ``force-level1-csd`` requires four mandatory arguments to be specified.

--- a/docs/source/history/vdev.rst
+++ b/docs/source/history/vdev.rst
@@ -11,6 +11,16 @@ FORCE-dev
   * :ref:`depend` have changed.
     Instead of python, python3 is now specifically required.
 
+* **FORCE LEVEL 1 ARCHIVING SYSTEM**
+
+    Stefan Ernst fixed some issues in force-csd.
+
+  * Reworked how AOIs in the form of vector files are handled.
+    Geopackages are no longer used as database for intersecting user-defined AOIs with the tiles/footprints of Sentinel-2 and Landsat, as the GDAL GPKG driver and SQLite caused issues with certains setups / installations. The geopackage format is still supported as AOI input though.
+
+  * Several small fixes
+    Fixes target the reprojection of AOIs, handling of negative values for AOI bounding boxes, command line option parsing, etc.
+
 * **FORCE L2PS**
 
   * Changed the BRDF correction strategy.

--- a/docs/source/howto/sentinel2-l1c.rst
+++ b/docs/source/howto/sentinel2-l1c.rst
@@ -3,7 +3,7 @@
 Sentinel-2 Level 1C
 ===================
 
-**How to download and manage Sentinel-2 Level 1C data from the ESA hub**
+**Download and manage Sentinel-2 Level 1C data**
 
 This tutorial explains how to use the FORCE Level 1 Archiving Suite (FORCE L1AS) to download, organize, and maintain a clean and consistent Sentinel-2 Level 1 data pool, as well as corresponding data queues needed for the Level 2 processing.
 
@@ -22,7 +22,7 @@ If a new file is sitting on ESA's end, the missing image is downloaded.
 A file queue is generated and updated accordingly - which is the main input to the FORCE Level 2 Processing System.
 
 
-.. figure:: img/tutorial-l1sen2.png" width="750
+.. figure:: img/tutorial-l1sen2.png
 
    *Sentinel-2 downloader in the **FORCE Level 1 Archiving Suite***
 
@@ -50,7 +50,7 @@ After setting up your account, you should be able to download Sentinel-2 data vi
 As with any other FORCE program, you can display short usage instructions by executing the program without any parameters.
 
 
-.. code-block:: bash
+.. code-block:: none
 
    force-level1-sentinel2
 
@@ -64,15 +64,12 @@ As with any other FORCE program, you can display short usage instructions by exe
     
       queue
       Downloaded files are appended to a file queue, which is needed for
-      the Level 2 processing.
-The file doesn't need to exist.
-If it exists,
-      new lines will be appended on successful ingestion
+      the Level 2 processing. The file doesn't need to exist.
+      If it exists, new lines will be appended on successful ingestion
     
       Boundingbox
       The coordinates of your study area: "X1/Y1,X2/Y2,X3/Y3,...,X1/Y1"
-      The box must be closed (first X/Y = last X/Y).
-X/Y must be given as
+      The box must be closed (first X/Y = last X/Y). X/Y must be given as
       decimal degrees with negative values for West and South coordinates.
       Note that the box doesn't have to be square, you can specify a polygon
     
@@ -82,8 +79,9 @@ X/Y must be given as
       min-cc max-cc
       The cloud cover range must be given in %
     
-      dry will trigger a dry run that will only return the number of images
-      and their total data volume
+      dry
+      will trigger a dry run that will only return the number of images and
+      their total data volume
     
       Your ESA credentials must be placed in /home/frantzda/.scihub
         First line: User name
@@ -106,7 +104,7 @@ If you don't receive any data for your study area, or end up somewhere else enti
 - Y = Latitude
 
 
-.. code-block:: bash
+.. code-block:: none
 
    force-level1-sentinel2 /data/Dagobah/S2L1C /data/Dagobah/S2L1C/zambia.txt "25.43/-12.46,25.94/-12.46,25.94/-11.98,25.39/-11.99,25.43/-12.46" 2019-07-01 2019-07-31 0 50 dry
 
@@ -132,7 +130,7 @@ Thus, FORCE iterates through the pages until no more image can be retrieved.
 Please note that download speed varies considerably.. 
 
 
-.. code-block:: bash
+.. code-block:: none
 
    force-level1-sentinel2 /data/Dagobah/S2L1C /data/Dagobah/S2L1C/zambia.txt "25.43/-12.46,25.94/-12.46,25.94/-11.98,25.39/-11.99,25.43/-12.46" 2019-07-01 2019-07-31 0 50
 
@@ -236,7 +234,7 @@ Thus, you can e.g. change the boundingbox, time frame or cloud coverage, and onl
 In the following example, the Eastern X-Coordinates were increased by 1 degree.
 
 
-.. code-block:: bash
+.. code-block:: none
 
    force-level1-sentinel2 /data/Dagobah/S2L1C /data/Dagobah/S2L1C/zambia.txt "25.43/-12.46,26.94/-12.46,26.94/-11.98,25.39/-11.99,25.43/-12.46" 2019-07-01 2019-07-31 0 50
 
@@ -347,10 +345,10 @@ Following line will start the download at 3:00 AM each day.
 *Replace YOURNAME with your user name.*
 
 
-.. code-block:: bash
+.. code-block:: none
 
    PATH=/home/YOURNAME/bin:/usr/bin:/bin:/usr/local/bin
-0 3 * * * force-level1-sentinel2 /data/Dagobah/S2L1C /data/Dagobah/S2L1C/zambia.txt "25.43/-12.46,26.94/-12.46,26.94/-11.98,25.39/-11.99,25.43/-12.46" 2018-07-01 2018-07-31 0 50
+   0 3 * * * force-level1-sentinel2 /data/Dagobah/S2L1C /data/Dagobah/S2L1C/zambia.txt "25.43/-12.46,26.94/-12.46,26.94/-11.98,25.39/-11.99,25.43/-12.46" 2018-07-01 2018-07-31 0 50
 
 
 ----------
@@ -375,7 +373,7 @@ FORCE L1AS needs to be run again to retrieve the restored data.
 To this end, it comes in handy to set up a download scheduler as desribed above.
 
 
-.. code-block:: bash
+.. code-block:: none
 
    force-level1-sentinel2 /data/Dagobah/S2L1C /data/Dagobah/S2L1C/zambia.txt "25.43/-12.46,25.94/-12.46,25.94/-11.98,25.39/-11.99,25.43/-12.46" 2018-07-01 2018-07-31 0 50
 
@@ -383,47 +381,47 @@ To this end, it comes in handy to set up a download scheduler as desribed above.
     2020-02-15_15:49:18 - Found 12 S2A/B files.
     2020-02-15_15:49:18 - Found 12 S2A/B files on this page.
     S2B_MSIL1C_20180730T081559_N0206_R121_T35LLG_20180730T141111.SAFE: Pulling from Long Term Archive.
-Success.
-Rerun this program after a while
+    Success.
+    Rerun this program after a while
     S2B_MSIL1C_20180727T080609_N0206_R078_T35LLG_20180727T121446.SAFE: Pulling from Long Term Archive.
-Failed.
-You have exhausted your user quota.
-Rerun this program after a while
+    Failed.
+    You have exhausted your user quota.
+    Rerun this program after a while
     S2A_MSIL1C_20180725T081601_N0206_R121_T35LLG_20180725T121615.SAFE: Pulling from Long Term Archive.
-Failed.
-You have exhausted your user quota.
-Rerun this program after a while
+    Failed.
+    You have exhausted your user quota.
+    Rerun this program after a while
     S2A_MSIL1C_20180722T080611_N0206_R078_T35LLG_20180722T115605.SAFE: Pulling from Long Term Archive.
-Failed.
-You have exhausted your user quota.
-Rerun this program after a while
+    Failed.
+    You have exhausted your user quota.
+    Rerun this program after a while
     S2B_MSIL1C_20180720T081559_N0206_R121_T35LLG_20180720T121127.SAFE: Pulling from Long Term Archive.
-Failed.
-You have exhausted your user quota.
-Rerun this program after a while
+    Failed.
+    You have exhausted your user quota.
+    Rerun this program after a while
     S2B_MSIL1C_20180717T080609_N0206_R078_T35LLG_20180717T120239.SAFE: Pulling from Long Term Archive.
-Failed.
-You have exhausted your user quota.
-Rerun this program after a while
+    Failed.
+    You have exhausted your user quota.
+    Rerun this program after a while
     S2A_MSIL1C_20180715T081601_N0206_R121_T35LLG_20180715T103432.SAFE: Pulling from Long Term Archive.
-Failed.
-You have exhausted your user quota.
-Rerun this program after a while
+    Failed.
+    You have exhausted your user quota.
+    Rerun this program after a while
     S2A_MSIL1C_20180712T080611_N0206_R078_T35LLG_20180712T102334.SAFE: Pulling from Long Term Archive.
-Failed.
-Too Many Requests
+    Failed.
+    Too Many Requests
     S2B_MSIL1C_20180710T081559_N0206_R121_T35LLG_20180710T120813.SAFE: Pulling from Long Term Archive.
-Failed.
-Too Many Requests
+    Failed.
+    Too Many Requests
     S2B_MSIL1C_20180707T080609_N0206_R078_T35LLG_20180707T115209.SAFE: Pulling from Long Term Archive.
-Failed.
-Too Many Requests
+    Failed.
+    Too Many Requests
     S2A_MSIL1C_20180705T081601_N0206_R121_T35LLG_20180705T103349.SAFE: Pulling from Long Term Archive.
-Failed.
-Too Many Requests
+    Failed.
+    Too Many Requests
     S2A_MSIL1C_20180702T080611_N0206_R078_T35LLG_20180702T115230.SAFE: Pulling from Long Term Archive.
-Failed.
-Too Many Requests
+    Failed.
+    Too Many Requests
 
 
 ------------

--- a/docs/source/howto/sentinel2-l1c.rst
+++ b/docs/source/howto/sentinel2-l1c.rst
@@ -3,7 +3,7 @@
 Sentinel-2 Level 1C
 ===================
 
-**Download and manage Sentinel-2 Level 1C data**
+**How to download and manage Sentinel-2 Level 1C data from the ESA hub**
 
 This tutorial explains how to use the FORCE Level 1 Archiving Suite (FORCE L1AS) to download, organize, and maintain a clean and consistent Sentinel-2 Level 1 data pool, as well as corresponding data queues needed for the Level 2 processing.
 


### PR DESCRIPTION
- In response to multiple problems with the geopackage formate, geopackages are no longer used as database for intersecting user-defined AOIs with the tiles/footprints of Sentinel-2 and Landsat. The GDAL GPKG driver and SQLite caused issues with certains setups / installations (see #48 and #49 ). The geopackage format is still supported as AOI input.

- Several small fixes

    Fixes target the reprojection of AOIs, handling of negative values for AOI bounding boxes, protecting paths, etc.