### PR TITLE
Ignore duplicate Landsat scenes in GCS

### DIFF
--- a/bash/force-level1-csd.sh
+++ b/bash/force-level1-csd.sh
@@ -422,7 +422,6 @@ get_data() {
     sed -i "1 s/^/$(head -n 1 $METACAT)\n/" $METAFNAME
     mv $METAFNAME "${METAFNAME/_metadata_/_metadata_"$SATELLITE"_}"
   fi
-  exit
 
 
   # ============================================================


### PR DESCRIPTION
Fix for #52 level1-csd: Duplicate Landsat scenes downloaded.

Only the product with the latest processing datestamp is downloaded if there are several products for one WRS-2 footprint on the same day.