### PR TITLE
add --embed to LDPYTHON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ LDGSL=-lgsl -lgslcblas
 #LDSPLITS=-lsplits -larmadillo
 LDOPENCV=-lopencv_core -lopencv_ml -lopencv_imgproc
 LDCURL=-lcurl
-LDPYTHON != python3-config --libs --embed
+LDPYTHON != (python3-config --libs --embed || python3-config --libs) | tail -n 1
 
 # NO! changes below this line (unless you know what to do, then go ahead)
 ##########################################################################

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ LDGSL=-lgsl -lgslcblas
 #LDSPLITS=-lsplits -larmadillo
 LDOPENCV=-lopencv_core -lopencv_ml -lopencv_imgproc
 LDCURL=-lcurl
-LDPYTHON != python3-config --libs
+LDPYTHON != python3-config --libs --embed
 
 # NO! changes below this line (unless you know what to do, then go ahead)
 ##########################################################################


### PR DESCRIPTION
Without `--embed`, the python library itself (lpython) is not included in the `python3-config --libs` output, and building FORCE fails (at least for me, that is on a ubuntu 20.04 based docker image) with lots of undefined references when building force-qai-inflate. Including `--embed` fixes the issue.