### PR TITLE
Add nanoseconds to temporary filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Framework for Operational Radiometric Correction for Environmental monitoring**
 
-**Version 3.6.4**
+**Version 3.6.5**
 
 ![FORCE Logo](/images/force.png)
 

--- a/bash/force-level1-csd.sh
+++ b/bash/force-level1-csd.sh
@@ -353,7 +353,7 @@ get_data() {
 
   if [ "$AOITYPE" -eq 1 ]; then
     printf "%s\n" "" "Searching for footprints / tiles intersecting with geometries of AOI shapefile..."
-    OGRTEMP="$POOL"/l1csd-temp_$(date +%FT%H-%M-%S)
+    OGRTEMP="$POOL"/l1csd-temp_$(date +%FT%H-%M-%S-%N)
     mkdir "$OGRTEMP"
     # get first layer of vector file and reproject to epsg4326
     AOILAYER=$(ogrinfo "$AOI" | grep "1: " | sed "s/1: //; s/ ([[:alnum:]]*.*)//")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ FORCE documentation
 
 **FORCE: Framework for Operational Radiometric Correction for Environmental monitoring**
 
-**Version 3.6.4**
+**Version 3.6.5**
 
 `Download from Github <https://github.com/davidfrantz/force>`_.
 

--- a/src/cross-level/_version-cl.h
+++ b/src/cross-level/_version-cl.h
@@ -32,7 +32,7 @@ Version number
 extern "C" {
 #endif
 
-#define _VERSION_ "3.6.4"
+#define _VERSION_ "3.6.5"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description

This minimal change avoids malfunctions if two or more calls to `force-level1-csd` happen in the very same second.

The change...
- ... adds extra information without removing anything →  is backwards compatible
- ... only affects the name of a temporary folder → has no permanent side effects
- ... will still fail if the calls happen in the same nanosecond, but the chances are a thousand-millionth lower 🤓

## Context

I found this problem when parallelizing the download of `level1` data using `force-level1-csd`. Specifically, I split the time intervals in, for instance, 4 subintervals, and afterward process each subinterval in a different core. I needed this _"hack"_ to make it work.

## Other

I am very interested in knowing if the authors recommend a better way of parallelizing this step.

All the best.

