### PR TITLE
Fix error when using -n as first option

### DIFF
--- a/bash/force-level1-csd.sh
+++ b/bash/force-level1-csd.sh
@@ -127,7 +127,7 @@ UPDATE=0
 KEEPMETA=0
 
 # Negative coordinates: change ( -) to %dummy% if followed by integer: prevent interpretation as option by getopt
-ARGS=$(echo "$@" | sed -E "s/ -([0-9])/ %dummy%\1/g")
+ARGS=$(echo "$*" | sed -E "s/ -([0-9])/ %dummy%\1/g")
 set -- $ARGS
 
 ARGS=`getopt -o c:d:nks:t:u -l cloudcover:,daterange:,no-act,keep-meta,sensors:,tier:,update -n $0 -- "$@"`
@@ -169,7 +169,6 @@ done
 # change %dummy% back to -
 ARGS=$(echo "$@" | sed -E "s/%dummy%([0-9])/-\1/g")
 eval set -- "$ARGS"
-
 
 # Check for update flag and update metadata catalogue if set
 if [ $UPDATE -eq 1 ]; then


### PR DESCRIPTION
Fixed: The -n argument does not keep force-level1-csd from downloading files if it is set as first argument.
Background: arguments run through a substitution before being parsed by getopt to avoid issues with negative coordinates being detected as arguments by getopt. Using `$*` instead of `$@` when echoing arguments before piping to `sed` now, this avoids `echo` interpreting `-n` as argument.

This fix relates to #77 and #80 