### PR TITLE
Add nanoseconds to METAFNAME

### DIFF
--- a/bash/force-level1-csd.sh
+++ b/bash/force-level1-csd.sh
@@ -421,7 +421,7 @@ get_data() {
     LINKS=$(grep -E $TILES $METACAT | grep -E $(echo ""$SENSORS"" | sed 's/ /_|/g')"_" | grep -E $(echo "_"$TIER | sed 's/,/,|_/g')"," | awk -F "," '{OFS=","} {gsub("-","",$5)}1' | awk -v start="$DATEMIN" -v stop="$DATEMAX" -v clow="$CCMIN" -v chigh="$CCMAX" -F "," '$5 >= start && $5 <= stop && $6 == 01 && $12 >= clow && $12 <= chigh' | sort -t"," -k 2.27,2.34r | awk -F"," '{OFS=","} !a[$10$11,$5]++' | sort -t"," -k 5)
   fi
 
-  METAFNAME="$POOL"/csd_metadata_$(date +%FT%H-%M-%S).txt
+  METAFNAME="$POOL"/csd_metadata_$(date +%FT%H-%M-%S-%N).txt
   printf "%s" "$LINKS" > $METAFNAME
   case $SATELLITE in
     sentinel2) TOTALSIZE=$(printf "%s" "$LINKS" | awk -F "," '{s+=$6/1048576} END {printf "%f", s}') ;;


### PR DESCRIPTION
## Context

This pull request is strongly related to #66.

## Problem

After trying the parallelization scheme described in #66 on an HPC, we noticed that there is another naming conflict. For some reason, this problem didn't appear when I tried the workflow on my laptop. 

## Solution

This tiny patch, basically identical to that of #66, solves it in a backward-compatible way.

Thanks in advance for your time!