### PR TITLE
Threadpool exits on SIGINT (Issue #172)

### DIFF
--- a/src/higher-level/py-udf-hl.c
+++ b/src/higher-level/py-udf-hl.c
@@ -87,8 +87,11 @@ par_udf_t *udf;
   PyRun_SimpleString("import numpy as np");
   PyRun_SimpleString("from datetime import date as Date");
   PyRun_SimpleString("import traceback");
+  PyRun_SimpleString("import signal");
 
-  PyRun_SimpleString("def init(): np.seterr(all='ignore')");
+  PyRun_SimpleString("def init():                                                  \n"
+					 "    np.seterr(all='ignore')                                  \n"
+					 "    signal.signal(signal.SIGINT, signal.SIG_DFL)             \n");
   PyRun_SimpleString("init()");
 
   PyRun_SimpleString(

--- a/src/higher-level/py-udf-hl.c
+++ b/src/higher-level/py-udf-hl.c
@@ -90,8 +90,8 @@ par_udf_t *udf;
   PyRun_SimpleString("import signal");
 
   PyRun_SimpleString("def init():                                                  \n"
-					 "    np.seterr(all='ignore')                                  \n"
-					 "    signal.signal(signal.SIGINT, signal.SIG_DFL)             \n");
+                     "    np.seterr(all='ignore')                                  \n"
+                     "    signal.signal(signal.SIGINT, signal.SIG_DFL)             \n");
   PyRun_SimpleString("init()");
 
   PyRun_SimpleString(


### PR DESCRIPTION
For a description of the problem, see #172. 

The _resources_ I found/used and which may (or may not) be useful for anyone else, are: 
- https://xcodest.me/interrupt-the-python-multiprocessing-pool-in-graceful-way.html
-  https://stackoverflow.com/questions/11312525/catch-ctrlc-sigint-and-exit-multiprocesses-gracefully-in-python
- https://bugs.python.org/issue9205
- https://stackoverflow.com/questions/51978956/cant-kill-multiprocessing-pool-in-a-multithreaded-c-application-embedding-pytho
*However*. I can't remember what finally tipped me off in the right direction...