### PR TITLE
Landsat path/row input check fixed

### DIFF
--- a/bash/force-level1-csd.sh
+++ b/bash/force-level1-csd.sh
@@ -350,7 +350,7 @@ if [ -z $AOITYPE ]; then
       if $(echo $ENTRY | grep -q -E "[0-2][0-9]{2}[0-2][0-9]{2}"); then
         LSPATH="${ENTRY:0:3}"
         LSROW="${ENTRY:3:6}"
-        if [ $(is_in_range $LSPATH 1 233) -eq 0 ] || [ $(is_in_range $LSPATH 1 248) -eq 0 ]; then
+        if [ $(is_in_range $LSPATH 1 233) -eq 0 ] || [ $(is_in_range $LSROW 1 248) -eq 0 ]; then
           show_help "$(printf "%s\n       " "Landsat PATH / ROW out of range. PATH not in range 1 to 233 or ROW not in range 1 to 248." "PATH / ROW received: $ENTRY")"
         fi
         continue


### PR DESCRIPTION
Minor fix: user input for Landsat paths was not checked due to a typo.