### PR TITLE
force-cube: remove empty tile directories

### DIFF
--- a/bash/force-cube.sh
+++ b/bash/force-cube.sh
@@ -154,6 +154,9 @@ function cubethis(){
 
     if [ $VALID -eq 0 ]; then
       rm "$FOUT"
+      if [ -z "$(ls -A "$DOUT/$TILE")" ]; then
+        rmdir "$DOUT/$TILE"
+      fi
       exit 1
     fi
 
@@ -181,6 +184,9 @@ function cubethis(){
 
     if [ $VALID -eq 0 ]; then
       rm "$FOUT"
+      if [ -z "$(ls -A "$DOUT/$TILE")" ]; then
+        rmdir "$DOUT/$TILE"
+      fi
       exit 1
     fi
 


### PR DESCRIPTION
#201
Added a conditional that removes empty tile directories if the corresponding cubed tiff was removed because it doesn't contain any valid data.