### PR TITLE
Add warning about Landsat Collection 1 data

### DIFF
--- a/bash/force-level1-csd.sh
+++ b/bash/force-level1-csd.sh
@@ -223,6 +223,9 @@ if [ $# -ne 4 ]; then
 fi
 
 which_satellite
+if [ $LANDSAT -eq 1 ]; then
+  printf "%s\n" "" "Warning: Google Cloud Storage only hosts Landsat Collection 1 data." "It is strongly recommended to use Collection 2 data: https://www.usgs.gov/landsat-missions/landsat-collection-2" "Collection 2 data is provided by the USGS, you may use https://github.com/ernstste/landsatlinks to query the catalogue and create download links."
+fi
 
 # ============================================================
 # Check user input and set up variables


### PR DESCRIPTION
Added a warning about Landsat Collection 2 data not being available in Google Cloud Storage. 
A GEE developer confirmed that C2 will not be added to GCS in a forum post.

force-level1-csd will now print a warning every time that Landsat data is requested and provide links to the C2 product description on the USGS website, as well as the landsatlinks github repository.