### PR TITLE
Update force-cube.sh

### DIFF
--- a/bash/force-cube.sh
+++ b/bash/force-cube.sh
@@ -64,7 +64,7 @@ Usage: $PROG [-hvirsantobj] input-file(s)
   -v = show version
   -i = show program's purpose
   -r = resampling method
-       any GDAL resampling method for raster data, e.g. cubic (default)
+       any GDAL resampling method for raster data, e.g. near (default)
        is ignored for vector data
   -s = pixel resolution of cubed data, defaults to 10
   -a = optional attribute name for vector data. $PROG will burn these values 
@@ -216,7 +216,7 @@ ARGS=`getopt -o hvir:s:o:b:j:a:n:t:l: --long help,version,info,resample:,resolut
 if [ $? != 0 ] ; then help; fi
 eval set -- "$ARGS"
 
-RESAMPLE="cubic"
+RESAMPLE="near"
 RES=10
 DOUT=$PWD
 BASE="DEFAULT"


### PR DESCRIPTION
I suggest to set the default resampling option in force-cube to nearest neighbour, which is in line with the gdalwarp settings (https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r), as this is also stated in the error message that force-cube throws when an unknown resampling algorithm is chosen.
Another option would be to not call gdalwarp at all if an unknown method is given and throw an individual error message.