### PR TITLE
check for/remove empty tile dirs after cubing, rather than on-the-fly

### DIFF
--- a/bash/force-cube.sh
+++ b/bash/force-cube.sh
@@ -154,9 +154,6 @@ function cubethis(){
 
     if [ $VALID -eq 0 ]; then
       rm "$FOUT"
-      if [ -z "$(ls -A "$DOUT/$TILE")" ]; then
-        rmdir "$DOUT/$TILE"
-      fi
       exit 1
     fi
 
@@ -184,9 +181,6 @@ function cubethis(){
 
     if [ $VALID -eq 0 ]; then
       rm "$FOUT"
-      if [ -z "$(ls -A "$DOUT/$TILE")" ]; then
-        rmdir "$DOUT/$TILE"
-      fi
       exit 1
     fi
 
@@ -410,6 +404,8 @@ for i in "$@"; do
 
   # remove the temporary file
   rm "$FTMP"
+  # remove empty folders in datacube
+  find $DOUT -type d -regextype grep -regex ".*X[0-9-]\{4\}_Y[0-9-]\{4\}" -empty -delete
 
 done
 


### PR DESCRIPTION
Reverting [152e9bd](https://github.com/ernstste/force/commit/152e9bd9651547682a263104e1d172f071705769) to avoid a potential race condition that may occure if several files are being cubed in parallel, see #226. 
Checking and removing empty tile directories now happens at the end of the script, after cubing has finished.
