### PR TITLE
speed up force-mosaic

### DIFF
--- a/bash/force-mosaic.sh
+++ b/bash/force-mosaic.sh
@@ -202,7 +202,7 @@ ROUT=$(perl -e 'use File::Spec; print File::Spec->abs2rel(@ARGV) . "\n"' "$FINP"
 export ROUT
 debug "relative output path: $ROUT"
 
-find -L "$ROUT" \( -name '*.dat' -o -name '*.tif' \) -exec basename {} \; | sort | uniq > $PRODUCTS
+find -L "$ROUT" \( -name '*.dat' -o -name '*.tif' \) | xargs basename -a | sort | uniq > $PRODUCTS
 NPROD=$(wc -l $PRODUCTS | cut -d " " -f 1)
 
 echo "mosaicking $NPROD products:"


### PR DESCRIPTION
This speeds up force-mosaic by avoiding the call to `basename` for each file.