### PR TITLE
landsatlinks integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,13 +52,14 @@ RUN echo "building FORCE" && \
   cd $HOME && \
   rm -rf $SOURCE_DIR && \
   force && \
-# clone FORCE UDF
+  # clone FORCE UDF
   git clone https://github.com/davidfrantz/force-udf.git
 
 FROM davidfrantz/base:latest as force
 
 COPY --chown=docker:docker --from=force_builder $HOME/bin $HOME/bin
 COPY --chown=docker:docker --from=force_builder $HOME/force-udf $HOME/udf
+COPY --chown=docker:docker --from=force_builder /usr/local/bin/landsatlinks $HOME/bin/force-level1-landsat
 
 WORKDIR /home/docker
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ OK := $(foreach exec,$(EXECUTABLES),\
 ### EXECUTABLES AND MISC FILES TO BE CHECKED
 
 FORCE_EXE = force force-cube force-higher-level force-import-modis \
-            force-l2ps force-l2ps_ force-level1-csd force-level1-landsat \
+            force-l2ps force-l2ps_ force-level1-csd \
             force-level1-sentinel2 force-level2 force-lut-modis \
             force-magic-parameters force-mdcp force-mosaic force-parameter \
             force-procmask force-pyramid force-qai-inflate force-stack \
@@ -441,7 +441,6 @@ bash: temp
 	cp $(DB)/force-cube.sh $(TB)/force-cube
 	cp $(DB)/force-l2ps_.sh $(TB)/force-l2ps_
 	cp $(DB)/force-level1-csd.sh $(TB)/force-level1-csd  
-	cp $(DB)/force-level1-landsat.sh $(TB)/force-level1-landsat
 	cp $(DB)/force-level1-sentinel2.sh $(TB)/force-level1-sentinel2
 	cp $(DB)/force-level2.sh $(TB)/force-level2
 	cp $(DB)/force-mosaic.sh $(TB)/force-mosaic

--- a/src/aux-level/_main.c
+++ b/src/aux-level/_main.c
@@ -106,8 +106,8 @@ char user[NPOW_10];
          user, _VERSION_);
   printf("Framework for Operational Radiometric Correction for "
          "Environmental monitoring\n");
-  printf("Copyright (C) 2013-2021 David Frantz, "
-         "david.frantz@geo.hu-berlin.de\n");
+  printf("Copyright (C) 2013-2022 David Frantz, "
+         "david.frantz@uni-trier.de\n");
   printf("+ many community contributions.\n");
 
   printf("\nFORCE is free software under the terms of the "
@@ -144,8 +144,8 @@ char user[NPOW_10];
          "\nLevel 1 Archiving System (L1AS)\n"
          "+ force-level1-csd       Download from cloud storage + maintenance of Level 1 "
          "Landsat and Sentinel-2 data pool\n"
-         "+ force-level1-landsat   Maintenance of Level 1 Landsat "
-         "data pool (deprecated)\n"
+         "+ force-level1-landsat   Download Landsat data using the USGS M2M API "
+         "+ maintenance of Level 1 data pool\n"
          "+ force-level1-sentinel2 Download from ESA + maintenance of Level 1 "
          "Sentinel-2 data pool (deprecated)\n"
          "\nLevel 2 Processing System (L2PS)\n"


### PR DESCRIPTION
This PR is part of the landsatlinks integration as force-level1-landsat, related PR: https://github.com/davidfrantz/base_image/pull/2.

1. remove the deprecated force-level1-landsat from makefile
2. make landsatlinks available as force-level1-landsat in Docker
3. update the print that is shown when force is run without arguments (I noticed it still was prinitng your old email and took the liberty to change that as well)