### PR TITLE
fix use of non-existing bash variable

### DIFF
--- a/bash/force-level1-csd.sh
+++ b/bash/force-level1-csd.sh
@@ -305,7 +305,7 @@ else
 fi
 export BOTO_CONFIG
 if [ ! -r $BOTO_CONFIG ]; then
-  show_help "$(printf "%s\n       " "gsutil config file was not found in $CREDDIR.")"
+  show_help "$(printf "%s\n       " "gsutil config file was not found in $FORCE_CREDENTIALS.")"
 fi
 
 


### PR DESCRIPTION
Now merging into develop branch.

Description copied from #300:
> I apparently misconfigured the gsutil configuration and the .boho credentials file cannot be found.
> When investigating I noticed that the variable is likely wrong, which is fixed in this commit. Also puts the output in ', as first I misread the sentence end dot with a linux current directory dot.
