### PR TITLE
update force-cube (fix #315)

### DIFF
--- a/bash/force-cube.sh
+++ b/bash/force-cube.sh
@@ -41,6 +41,7 @@ export RASTER_INFO_EXE="gdalinfo"
 export VECTOR_INFO_EXE="ogrinfo"
 export VECTOR_WARP_EXE="ogr2ogr"
 export RASTER_WARP_EXE="gdalwarp"
+export RASTER_WARP_HELP="--help"
 export RASTER_MERGE_EXE="gdal_merge.py"
 export RASTERIZE_EXE="gdal_rasterize"
 export PARALLEL_EXE="parallel"
@@ -236,7 +237,7 @@ fi
 debug "$# input files will be cubed"
 
 # options received, check now ------------------------------------------------------------
-RESOPT=$($RASTER_WARP_EXE 2>/dev/null | grep -A 1 'Available resampling methods:')
+RESOPT=$($RASTER_WARP_EXE $RASTER_WARP_HELP | grep -A 2 'Available resampling methods:')
 TEMP=$(echo $RESOPT | sed 's/[., ]/%/g')
 if [[ ! $TEMP =~ "%$RESAMPLE%" ]]; then 
   echoerr "Unknown resampling method."; 

--- a/bash/force-cube.sh
+++ b/bash/force-cube.sh
@@ -41,7 +41,6 @@ export RASTER_INFO_EXE="gdalinfo"
 export VECTOR_INFO_EXE="ogrinfo"
 export VECTOR_WARP_EXE="ogr2ogr"
 export RASTER_WARP_EXE="gdalwarp"
-export RASTER_WARP_HELP="--help"
 export RASTER_MERGE_EXE="gdal_merge.py"
 export RASTERIZE_EXE="gdal_rasterize"
 export PARALLEL_EXE="parallel"
@@ -237,7 +236,7 @@ fi
 debug "$# input files will be cubed"
 
 # options received, check now ------------------------------------------------------------
-RESOPT=$($RASTER_WARP_EXE $RASTER_WARP_HELP | grep -A 2 'Available resampling methods:')
+RESOPT=$($RASTER_WARP_EXE --help 2>/dev/null | grep -A 2 'Available resampling methods:')
 TEMP=$(echo $RESOPT | sed 's/[., ]/%/g')
 if [[ ! $TEMP =~ "%$RESAMPLE%" ]]; then 
   echoerr "Unknown resampling method."; 


### PR DESCRIPTION
use explicit help flag on gdalwarp and grep two subsequent lines of output to get all available resampling methods in latest version of GDAL

Fixes #315 