### PR TITLE
Dockerfile: limit make parallelism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ COPY --chown=docker:docker . .
 RUN echo "building FORCE" && \
   ./debug.sh $debug && \
   sed -i "/^INSTALLDIR=/cINSTALLDIR=$INSTALL_DIR/" Makefile && \
-  make -j && \
+  make -j$(nproc) && \
   make install && \
   make clean && \
   cd $HOME && \


### PR DESCRIPTION
Build time improves if the number
of compilation procesess aren't
unlimited, so put an upper limit
of the number of cores on the build
machine.