### PR TITLE
Fail `force-cube` explicitly for missing features

### DIFF
--- a/bash/force-cube.sh
+++ b/bash/force-cube.sh
@@ -333,6 +333,14 @@ for i in "$@"; do
     fi
   fi
 
+  # is there at least one feature?
+  if [ "$RASTER" == "false" ]; then
+    N_FEATURES=$($VECTOR_INFO_EXE -ro $FINP $LAYER | grep "Feature Count" | tr -d ' ' | cut -d ':' -f2)
+    if [ $N_FEATURES == 0 ]; then
+      echoerr "no features found in input layer."; exit 1
+    fi
+  fi
+
   # bounding box
   if [ "$RASTER" == "true" ]; then
     FTMP="$FTMP.vrt"

--- a/bash/force-tile-extent.sh
+++ b/bash/force-tile-extent.sh
@@ -76,6 +76,11 @@ cp $DIR/datacube-definition.prj $TMP/datacube-definition.prj
 BINDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 $BINDIR"/"force-cube -j 0 -s 10 -o $TMP -b force-extent $INP &> /dev/null
 
+if [ $? == 1 ]; then
+  echoerr "force-cube returned an error."
+  echoerr "run '$BINDIR"/"force-cube -j 0 -s 10 -o $TMP -b force-extent $INP' to see where the error occured."
+  exit 1
+fi
 
 WD=$PWD
 cd $TMP


### PR DESCRIPTION
Previously, an vector file (e.g. GPKG) could be supplied with a corresponding layer name but a feature count of 0. This leads to `force-cube` getting stuck.

As this was discovered when using `force-tile-extent`, a check for the return value was added there with an error message indicating to the user what command to re-run to get more information during which step `force-cube` failed