### PR TITLE
Adding support for new format of gdalwarp --help

### DIFF
--- a/bash/force-cube.sh
+++ b/bash/force-cube.sh
@@ -245,8 +245,8 @@ debug "$# input files will be cubed"
 HELP_TEXT=$($RASTER_WARP_EXE --help 2>/dev/null) 
 RESOPT=$(echo "$HELP_TEXT" | grep -A 2 'Available resampling methods:')
 if [[ -z "$RESOPT" ]]; then
-    RAW=$(echo "$HELP_TEXT" | grep -o '\[-r [^]]*\]' | sed -E 's/^\[-r //; s/\]$//')
-    RESOPT="Available resampling methods:
+  RAW=$(echo "$HELP_TEXT" | grep -o '\[-r [^]]*\]' | sed -E 's/^\[-r //; s/\]$//')
+  RESOPT="Available resampling methods:
     $(echo "$RAW" | tr '|' ',' )"
 fi
 


### PR DESCRIPTION
`gdalwarp --help` changed it's formatting on newer versions of the library. This causes an early termination of `force-cube.sh`, which validates resampling methods by checking the `--help` command

Old (gdal 3.0.4 and further) - Note the last 2 lines
```bash
$ gdalwarp --help
Usage: gdalwarp [--help-general] [--formats]
    [-s_srs srs_def] [-t_srs srs_def] [-to "NAME=VALUE"]* [-novshiftgrid]
    [-order n | -tps | -rpc | -geoloc] [-et err_threshold]
    [-refine_gcps tolerance [minimum_gcps]]
    [-te xmin ymin xmax ymax] [-tr xres yres] [-tap] [-ts width height]
    [-ovr level|AUTO|AUTO-n|NONE] [-wo "NAME=VALUE"] [-ot Byte/Int16/...] [-wt Byte/Int16]
    [-srcnodata "value [value...]"] [-dstnodata "value [value...]"] -dstalpha
    [-r resampling_method] [-wm memory_in_mb] [-multi] [-q]
    [-cutline datasource] [-cl layer] [-cwhere expression]
    [-csql statement] [-cblend dist_in_pixels] [-crop_to_cutline]
    [-of format] [-co "NAME=VALUE"]* [-overwrite]
    [-nomd] [-cvmd meta_conflict_value] [-setci] [-oo NAME=VALUE]*
    [-doo NAME=VALUE]*
    srcfile* dstfile

Available resampling methods:
    near (default), bilinear, cubic, cubicspline, lanczos, average, mode,  max, min, med, Q1, Q3.
```

New (gdal 3.11.3 or earlier?)
```bash
$ gdalwarp --help
Usage: gdalwarp [--help] [--long-usage] [--help-general]
                [--quiet] [-overwrite] [-of <output_format>]
                [-co <NAME>=<VALUE>]... [-s_srs <srs_def>] [-t_srs <srs_def>]
                [[-srcalpha]|[-nosrcalpha]]
                [-dstalpha] [-tr <xres> <yres>|square] [-ts <width> <height>]
                [-te <xmin> <ymin> <xmax> <ymax>] [-te_srs <srs_def>]
                [-r near|bilinear|cubic|cubicspline|lanczos|average|rms|mode|min|max|med|q1|q3|sum]
                [-ot Byte|Int8|[U]Int{16|32|64}|CInt{16|32}|[C]Float{32|64}]
                <src_dataset_name>... <dst_dataset_name>

Advanced options:
                [-wo <NAME>=<VALUE>]... [-multi] [-s_coord_epoch <epoch>]
                [-t_coord_epoch <epoch>] [-ct <string>]
                [[-tps]|[-rpc]|[-geoloc]]
                [-order <1|2|3>] [-refine_gcps <tolerance> [<minimum_gcps>]]
                [-to <NAME>=<VALUE>]... [-et <err_threshold>]
                [-wm <memory_in_mb>] [-srcnodata "<value>[ <value>]..."]
                [-dstnodata "<value>[ <value>]..."] [-tap]
                [-wt Byte|Int8|[U]Int{16|32|64}|CInt{16|32}|[C]Float{32|64}]
                [-cutline <datasource>|<WKT>] [-cutline_srs <srs_def>]
                [-cwhere <expression>]
                [[-cl <layername>]|[-csql <query>]]
                [-cblend <distance>] [-crop_to_cutline] [-nomd]
                [-cvmd <meta_conflict_value>] [-setci] [-oo <NAME>=<VALUE>]...
                [-doo <NAME>=<VALUE>]... [-ovr <level>|AUTO|AUTO-<n>|NONE]
                [[-vshift]|[-novshiftgrid]]
                [-if <format>]... [-srcband <band>]... [-dstband <band>]...

Note: gdalwarp --long-usage for full help.
```

This PR provides a way to address both cases.

To test:
```bash
#calls force-cube internally
force-tile-extent {any aoi} -a tiles.txt
```