### PR TITLE
Enabling bash script debug statements in debug mode

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -52,6 +52,7 @@ fi
 
 if [ $enable -eq 1 ]; then
   sed -i -e 's%^[/]*\(#define FORCE_DEBUG\)%\1%' src/modules/cross-level/const-cl.h
+  sed -i 's/^export DEBUG=false$/export DEBUG=true/' bin/force-misc/force-bash-library.sh
 elif [ $enable -eq 0 ]; then
   sed -i -e 's%^[/]*\(#define FORCE_DEBUG\)%//\1%' src/modules/cross-level/const-cl.h
 fi

--- a/debug.sh
+++ b/debug.sh
@@ -52,7 +52,7 @@ fi
 
 if [ $enable -eq 1 ]; then
   sed -i -e 's%^[/]*\(#define FORCE_DEBUG\)%\1%' src/modules/cross-level/const-cl.h
-  sed -i 's/^export DEBUG=false$/export DEBUG=true/' bin/force-misc/force-bash-library.sh
+  sed -i 's/^export DEBUG=false$/export DEBUG=true/' misc/force-bash-library.sh
 elif [ $enable -eq 0 ]; then
   sed -i -e 's%^[/]*\(#define FORCE_DEBUG\)%//\1%' src/modules/cross-level/const-cl.h
 fi


### PR DESCRIPTION
`debug.sh` now also modifies `force-bash-library.sh` `DEBUG` variable when debug mode is enabled. 
This was done in order to show debug messages when running functions like `force-tile-extent` and other bash scripts.