### PR TITLE
Update parameter file and documentation for coregistration being possible for Landsat as well

### DIFF
--- a/docs/source/_static/parameter-files/parameter_LEVEL2.prm
+++ b/docs/source/_static/parameter-files/parameter_LEVEL2.prm
@@ -240,10 +240,9 @@ RES_MERGE = IMPROPHE
 
 # CO-REGISTRATION OPTIONS
 # ------------------------------------------------------------------------
-# This parameter only applies for Sentinel-2 data. This parameter defines
-# the path to a directory that contains monthly NIR base images.
-# If given, a co-registration is attempted. If it fails (no tie points),
-# the image won't be processed.
+# This parameter defines the path to a directory that contains monthly
+# NIR base images. If given, a co-registration is attempted.
+# If it fails (no tie points), the image won't be processed.
 # Type: full directory path
 DIR_COREG_BASE = NULL
 # This parameter defines the nodata values of the coregistration base images.

--- a/docs/source/_static/parameter-files/tutorials/lcf/10_lcf_level_2.prm
+++ b/docs/source/_static/parameter-files/tutorials/lcf/10_lcf_level_2.prm
@@ -223,10 +223,9 @@ RES_MERGE = IMPROPHE
 
 # CO-REGISTRATION OPTIONS
 # ------------------------------------------------------------------------
-# This parameter only applies for Sentinel-2 data. This parameter defines
-# the path to a directory that contains monthly Landsat NIR base images.
-# If given, a co-registration is attempted. If it fails (no tie points),
-# the image won't be processed.
+# This parameter defines the path to a directory that contains monthly
+# NIR base images. If given, a co-registration is attempted.
+# If it fails (no tie points), the image won't be processed.
 # Type: full directory path
 DIR_COREG_BASE = NULL
 # This parameter defines the nodata values of the coregistration base images.

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -28,7 +28,7 @@ Non-native data sources can also be processed, e.g. Sentinel-1 SAR data or envir
   * Adjacency effect correction. 
   * BRDF correction. 
   * Resolution merge of Sentinel-2 bands: 20m –> 10m. 
-  * Co-registration of Sentinel-2 images
+  * Co-registration of Sentinel-2 and Landsat images
   * Data cubing: reprojection / gridding.
 
 * **Generation of highly Analysis Ready Data (hARD): Large area. Gap free. Easy to use. Ideal input for Machine Learners!**

--- a/docs/source/howto/coreg.rst
+++ b/docs/source/howto/coreg.rst
@@ -14,6 +14,10 @@ I strongly suggest to read the :ref:`tut-ard` tutorial before.
 .. admonition:: Info
 
    *This tutorial uses FORCE v. 3.5*
+   
+   Please note that while this tutorial covers the original usage of the coregistration capabilities FORCE offers, it is possible
+   to coregister Landsat images with a Landsat time series as of version ``v. 3.8.00``! This may be beneficial when incorporating
+   Landsat Tier 2 data into a data cube.
 
 
 What is the problem?

--- a/docs/source/howto/l2-ard.rst
+++ b/docs/source/howto/l2-ard.rst
@@ -55,6 +55,10 @@ This includes three main processing steps:
 2. radiometric correction
 3. data cubing
 
+For Landsat, one additional option is implemented:
+
+1. co-registration with Landsat time series
+
 For Sentinel-2, two additional options are implemented:
 
 1. resolution merging, i.e. increase the spatial resolution of the 20m bands to 10m
@@ -252,6 +256,9 @@ Let's keep this method, but feel free to try the other options.
 
 Since v. 3.0, FORCE is able to perform a co-registration of Sentinel-2 images with Landsat time series.
 For starters, we will not use this option, but see the :ref:`tut-coreg` tutorial.
+
+.. note::
+   As of FORCE ``v. 3.8.00``, co-registration is also possible for Landsat imagery.
 
 
 8) Parallel Processing

--- a/src/modules/aux-level/param-aux.c
+++ b/src/modules/aux-level/param-aux.c
@@ -500,10 +500,9 @@ void write_par_ll_coreg(FILE *fp, bool verbose){
   fprintf(fp, "# ------------------------------------------------------------------------\n");
 
   if (verbose){
-    fprintf(fp, "# This parameter only applies for Sentinel-2 data. This parameter defines\n");
-    fprintf(fp, "# the path to a directory that contains monthly NIR base images.\n");
-    fprintf(fp, "# If given, a co-registration is attempted. If it fails (no tie points),\n");
-    fprintf(fp, "# the image won't be processed.\n");
+    fprintf(fp, "# This parameter defines the path to a directory that contains monthly\n");
+    fprintf(fp, "# NIR base images. If given, a co-registration is attempted.\n");
+    fprintf(fp, "# If it fails (no tie points), the image won't be processed.\n");
     fprintf(fp, "# Type: full directory path\n");
   }
   fprintf(fp, "DIR_COREG_BASE = NULL\n");


### PR DESCRIPTION
As of now, the documentation still refers to co-registration being available only for Sentinel-2 images. However, since version 3.8.0, it's also possible to co-register Landsat images.