### PR TITLE
Dockerfile: add git repo and copy with --link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ARG build=all
 # Copy src to SOURCE_DIR
 RUN mkdir -p $SOURCE_DIR
 WORKDIR $SOURCE_DIR
-COPY --chown=1000:1000 . .
+COPY --link --chown=1000:1000 . .
 
 # Build, install, check FORCE
 RUN echo "building FORCE" && \
@@ -58,7 +58,7 @@ FROM davidfrantz/base:latest AS force
 # Use numerical UID/GID to avoid name resolving issues with the non-default
 # Docker builders.
 ADD --link --chown=1000:1000 --exclude=.github https://github.com/davidfrantz/force-udf.git $HOME/udf
-COPY --chown=1000:1000 --from=force_builder $HOME/bin $HOME/bin
+COPY --link --chown=1000:1000 --from=force_builder $HOME/bin $HOME/bin
 
 WORKDIR /home/ubuntu
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ARG build=all
 # Copy src to SOURCE_DIR
 RUN mkdir -p $SOURCE_DIR
 WORKDIR $SOURCE_DIR
-COPY --chown=ubuntu:ubuntu . .
+COPY --chown=1000:1000 . .
 
 # Build, install, check FORCE
 RUN echo "building FORCE" && \
@@ -55,8 +55,10 @@ RUN echo "building FORCE" && \
 
 FROM davidfrantz/base:latest AS force
 
-ADD --link --chown=ubuntu:ubuntu --exclude=.github https://github.com/davidfrantz/force-udf.git $HOME/udf
-COPY --chown=ubuntu:ubuntu --from=force_builder $HOME/bin $HOME/bin
+# Use numerical UID/GID to avoid name resolving issues with the non-default
+# Docker builders.
+ADD --link --chown=1000:1000 --exclude=.github https://github.com/davidfrantz/force-udf.git $HOME/udf
+COPY --chown=1000:1000 --from=force_builder $HOME/bin $HOME/bin
 
 WORKDIR /home/ubuntu
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,24 @@
 # syntax=docker/dockerfile:1
 ##########################################################################
-# 
-# This file is part of FORCE - Framework for Operational Radiometric 
+#
+# This file is part of FORCE - Framework for Operational Radiometric
 # Correction for Environmental monitoring.
-# 
+#
 # Copyright (C) 2013-2022 David Frantz
-# 
+#
 # FORCE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # FORCE is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with FORCE. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 ##########################################################################
 
 # Copyright (C) 2020-2025 Gergely Padányi-Gulyás (github user fegyi001),

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ##########################################################################
 # 
 # This file is part of FORCE - Framework for Operational Radiometric 
@@ -50,14 +51,12 @@ RUN echo "building FORCE" && \
   make clean && \
   cd $HOME && \
   rm -rf $SOURCE_DIR && \
-  force-info && \
-# clone FORCE UDF
-  git clone https://github.com/davidfrantz/force-udf.git
+  force-info
 
 FROM davidfrantz/base:latest AS force
 
+ADD --link --chown=ubuntu:ubuntu --exclude=.github https://github.com/davidfrantz/force-udf.git $HOME/udf
 COPY --chown=ubuntu:ubuntu --from=force_builder $HOME/bin $HOME/bin
-COPY --chown=ubuntu:ubuntu --from=force_builder $HOME/force-udf $HOME/udf
 
 WORKDIR /home/ubuntu
 


### PR DESCRIPTION
Put the force-udf layer first since
that does not change frequently,
and add the repository directly
so the Docker cache can be used
to speed up the image build.

Also switch to using --link and numerical
UID/GID when copying, the first to get
the reasonable behavior from COPY,
and the second to avoid strange out
of bounds messages for people who
build the Force image with a non-default
Docker builder.