### PR TITLE
Makefile: add CCACHE variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ RSTATS_LIBS = $(shell R CMD config --ldflags | sed 's/ /\n/g' | grep '\-L') -lR
 CFLAGS=-O3 -Wall -fopenmp
 #CFLAGS=-g -Wall -fopenmp
 
-GCC=gcc $(CFLAGS)
-G11=g++ -std=c++11 $(CFLAGS)
+GCC=$(CCACHE) gcc $(CFLAGS)
+G11=$(CCACHE) g++ -std=c++11 $(CFLAGS)
 
 
 ##########################################################################


### PR DESCRIPTION
This corresponds to CMake's
\<LANG\>_COMPILER_LAUNCHER variable.
The variable is never set by anything
in this repository, so everything
behaves the same way before and after
this commit.