### PR TITLE
Remove pip3 requirement

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -26,7 +26,6 @@ requirements:
   - ogrinfo
   - opencv_version
   - parallel
-  - pip3
   - python3
   - R
   - rename


### PR DESCRIPTION
The base_image uses a build container
when installing the Python packages
now, so remove the pip3 requirement
for building FORCE.

This fixes the build of the FORCE
Docker image.