### PR TITLE
Makefile: add link-time optimization support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ COPY --link --chown=1000:1000 . .
 # Build, install, check FORCE
 RUN echo "building FORCE" && \
   ./debug.sh $debug && \
-  make -j$(nproc) $build
+  make LTO=yes -j$(nproc) $build
 
 FROM internal_base AS force
 

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,15 @@
 # Installation directory
 INSTALLDIR=/usr/local/bin
 
+# Link time optimization flags.
+ifeq ($(LTO),yes)
+  FLAGS_LTO = -flto
+endif
+
 # Libraries
 GDAL_INCLUDES = $(shell gdal-config --cflags)
 GDAL_LIBS = $(shell gdal-config --libs)
-GDAL_FLAGS = -Wl,-rpath=/usr/lib
+GDAL_FLAGS = $(FLAGS_LTO) -Wl,-rpath=/usr/lib
 
 GSL_INCLUDES = $(shell gsl-config --cflags)
 GSL_LIBS = $(shell gsl-config --libs)
@@ -57,7 +62,7 @@ RSTATS_LIBS = $(shell R CMD config --ldflags | sed 's/ /\n/g' | grep '\-L') -lR
 ### Compiler
 
 # Compilation Flags
-CFLAGS=-O3 -Wall -fopenmp
+CFLAGS=-O3 -Wall $(FLAGS_LTO) -fopenmp
 #CFLAGS=-g -Wall -fopenmp
 
 GCC=gcc $(CFLAGS)


### PR DESCRIPTION
Add flags for enabling link-time
optmization during compilation
by calling "make LTO=yes" and use
this in the Dockerfile.

I cannot find a definition of
LDFLAGS, so just chuck it into
GDAL_FLAGS which should be used
for the binaries that does heavy
computation.

I don't have any performance
comparisons, but compiling with LTO
makes the binary noticeably smaller,
before:

$ ls -l `which force-l2ps`
-rwxr-xr-x 1 root root 2668408 Mar 16 22:02 /usr/local/bin/force/force-l2ps

and after:

$ ls -l `which force-l2ps`
-rwxr-xr-x 1 root root 1986848 Mar 16 22:14 /usr/local/bin/force/force-l2ps

Reducing the binary size is likely
to improve the instruction cache
hit rate even if we pessimistically
assume that LTO didn't manage to make
any other optimization.